### PR TITLE
Update variable names

### DIFF
--- a/tools/rapids-package-name
+++ b/tools/rapids-package-name
@@ -6,11 +6,11 @@ set -eo pipefail
 
 echo_prefix="    [rapids-package-name] "
 
-if [[ ! -v GITHUB_REPOSITORY ]]; then
-    rapids-echo-stderr "${echo_prefix}Env var GITHUB_REPOSITORY must be set"
+if [[ ! -v RAPIDS_REPOSITORY ]]; then
+    rapids-echo-stderr "${echo_prefix}Env var RAPIDS_REPOSITORY must be set"
     exit 1
 fi
-repo_name="${GITHUB_REPOSITORY##*/}"
+repo_name="${RAPIDS_REPOSITORY##*/}"
 
 if [ -z "$1" ]; then
   rapids-echo-stderr "${echo_prefix}Must specify input arguments: PKG_TYPE"

--- a/tools/rapids-s3-path
+++ b/tools/rapids-s3-path
@@ -22,17 +22,17 @@ if [[ ! -v RAPIDS_BUILD_TYPE ]]; then
   exit 1
 fi
 
-if [[ ! -v GITHUB_SHA ]]; then
-  rapids-echo-stderr "${echo_prefix}Env var GITHUB_SHA must be set"
+if [[ ! -v RAPIDS_SHA ]]; then
+  rapids-echo-stderr "${echo_prefix}Env var RAPIDS_SHA must be set"
   exit 1
 fi
 
-if [[ ! -v GITHUB_REPOSITORY ]]; then
-  rapids-echo-stderr "${echo_prefix}Env var GITHUB_REPOSITORY must be set"
+if [[ ! -v RAPIDS_REPOSITORY ]]; then
+  rapids-echo-stderr "${echo_prefix}Env var RAPIDS_REPOSITORY must be set"
   exit 1
 fi
 
-repo_name="${GITHUB_REPOSITORY##*/}"
+repo_name="${RAPIDS_REPOSITORY##*/}"
 
 s3_directory_id=""
 s3_prefix=""
@@ -44,11 +44,11 @@ case "${RAPIDS_BUILD_TYPE}" in
     # more info:
     #    CopyPRs plugin in ops-bot: https://github.com/rapidsai/ops-bot#plugins
     #    https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
-    s3_directory_id="${GITHUB_REF_NAME##*/}"
+    s3_directory_id="${RAPIDS_REF_NAME##*/}"
     s3_prefix="ci"
     ;;
   branch)
-    s3_directory_id="${GITHUB_REF_NAME}"
+    s3_directory_id="${RAPIDS_REF_NAME}"
     s3_prefix="ci"
     ;;
   nightly)
@@ -61,7 +61,7 @@ case "${RAPIDS_BUILD_TYPE}" in
     ;;
 esac
 
-short_hash=${GITHUB_SHA:0:7}
+short_hash=${RAPIDS_SHA:0:7}
 
 s3_path="s3://rapids-downloads/${s3_prefix}/${repo_name}/"
 if [[ "${RAPIDS_BUILD_TYPE}" != "nightly" ]]; then


### PR DESCRIPTION
This PR updates some variable names for `rapids-package-name` and `rapids-s3-path`. These changes are necessary because the value of the corresponding `GITHUB_*` variables corresponds to the repository which initiated the GitHub Action run.

Consider the following GH Action runs:

- A PR workflow for `rmm` - The `rmm` repository is where the original GitHub Action run initiated. Therefore, all of the `GITHUB_*` variables correspond to the `rmm` repository like we'd expect
- A nightly "pipeline of pipelines" workflow<sup>1</sup> - An arbitrary repository is where the original GitHub Action run initiated. Therefore, all of the `GITHUB_*` variables correspond to that arbitrary repository

### Footnotes:

1. The nightly job that we run for RAPIDS is considered a "pipeline of pipelines" since it builds, tests, and uploads all of the RAPIDS libraries every night, in the order of their dependency tree. An initial example of this can be seen [here](https://github.com/rapidsai/actions/blob/main/.github/workflows/nightly-pipeline.yaml). At the time of this writing, it only has `rmm` in it.