### PR TITLE
Fix variable check logic in rapids-size-checker

### DIFF
--- a/tools/rapids-size-checker
+++ b/tools/rapids-size-checker
@@ -3,7 +3,7 @@ set -e
 
 echo_prefix="    [rapids-size-checker] "
 
-if [ -v RAPIDS_GH_TOKEN ] || [ -z "${RAPIDS_GH_TOKEN}" ]; then
+if [ ! -v RAPIDS_GH_TOKEN ] || [ -z "${RAPIDS_GH_TOKEN}" ]; then
   rapids-echo-stderr "${echo_prefix}Env var RAPIDS_GH_TOKEN must be set and not empty"
   exit 1
 fi


### PR DESCRIPTION
From Bash man:
```
-v varname
    True if the shell variable varname is set (has been assigned a value).
```
We want to apply the `if` if the variable is not defined