### PR TITLE
Add RAPIDS_ARCH to override host arch

### DIFF
--- a/tools/rapids-package-name
+++ b/tools/rapids-package-name
@@ -56,9 +56,9 @@ if (( append_pyver == 1 )); then
 fi
 
 # for cpp and python package types, always append arch
-if [[ -v RAPIDS_PY_WHEEL_ARCH ]] && [[ "${RAPIDS_PY_WHEEL_ARCH}" != "" ]]; then
+if [[ -v RAPIDS_ARCH ]] && [[ "${RAPIDS_ARCH}" != "" ]]; then
   # use arch override if specified
-  pkg_name+="_${RAPIDS_PY_WHEEL_ARCH}"
+  pkg_name+="_${RAPIDS_ARCH}"
 else
   # otherwise use architecture of the host that's running the upload command
   pkg_name+="_$(arch)"


### PR DESCRIPTION
In cibuildwheel's publish step, I found it wasteful to have to launch separate x86_64 and aarch64 runners to simply download and re-upload a built wheel.

With this change, a runner can force a specific architecture of a package name, so one runner can download both architectures.

Example:
```
RAPIDS_ARCH="x86_64" rapids-download-wheels-from-s3 ./dist
RAPIDS_ARCH="aarch64" rapids-download-wheels-from-s3 ./dist
twine upload ./dist/*.whl
```