### PR TITLE
Use `rapids-is-stable-build` in `rapids-env-update`

### DIFF
--- a/tools/rapids-env-update
+++ b/tools/rapids-env-update
@@ -4,14 +4,14 @@
 # a nightly or stable build is occurring.
 set -e
 
-# Remove nightly channels if we are building main branch
-if [[ "${GITHUB_REF_NAME}" = "main" ]]; then
+# Remove nightly channels if build is a stable build
+if rapids-is-stable-build; then
   conda config --system --remove channels rapidsai-nightly
   conda config --system --remove channels dask/label/dev
 fi
 
-# If nightly build, append current YYMMDD to version
-if [[ "${RAPIDS_BUILD_TYPE}" != "pull-request" && "${GITHUB_REF_NAME}" = branch-* ]] ; then
+# If nightly or branch build, append current YYMMDD to version
+if [[ "${RAPIDS_BUILD_TYPE}" != "pull-request" ]] && ! ./tools/rapids-is-stable-build; then
   VERSION_SUFFIX=$(date +%y%m%d)
   export VERSION_SUFFIX
 fi

--- a/tools/rapids-is-stable-build
+++ b/tools/rapids-is-stable-build
@@ -7,8 +7,11 @@
 #    if ./tools/rapids-is-stable-build; then echo "hi"; fi
 set -e
 
+echo_prefix="    [rapids-is-stable-build]"
+
 if [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9]{2}.[0-9]{2}.[0-9]{2}$ ]]; then
+  rapids-echo-stderr "${echo_prefix} is stable build"
   exit 0
 fi
-
+rapids-echo-stderr "${echo_prefix} is not stable build"
 exit 1


### PR DESCRIPTION
This PR includes the following two changes:

- Uses `rapids-is-stable-build` in `rapids-env-update`
- Adds some logging to `rapids-is-stable-build`