### PR TITLE
Add `ConnectionError:` to `rapids-conda-retry`

### DIFF
--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -97,6 +97,9 @@ function runConda {
         elif grep -q EOFError: "${outfile}"; then
             retryingMsg="Retrying, found 'EOFError:' in output..."
             needToRetry=1
+        elif grep -q ConnectionError: "${outfile}"; then
+            retryingMsg="Retrying, found 'ConnectionError:' in output..."
+            needToRetry=1
         elif grep -q "Multi-download failed" "${outfile}"; then
             retryingMsg="Retrying, found 'Multi-download failed' in output..."
             needToRetry=1


### PR DESCRIPTION
This PR adds a rule for `ConnectionError`s to `rapids-conda-retry`. This should hopefully solve transient errors like the one in the log below.

- https://github.com/rapidsai/rmm/actions/runs/3107844428/jobs/5036710751