### PR TITLE
Fix rapids-env-update to use rapids-is-release-build

### DIFF
--- a/tools/rapids-env-update
+++ b/tools/rapids-env-update
@@ -4,14 +4,14 @@
 # a nightly or stable build is occurring.
 set -e
 
-# Remove nightly channels if build is a stable build
-if rapids-is-stable-build; then
+# Remove nightly channels if build is a release build
+if rapids-is-release-build; then
   conda config --system --remove channels rapidsai-nightly
   conda config --system --remove channels dask/label/dev
 fi
 
 # If nightly or branch build, append current YYMMDD to version
-if [[ "${RAPIDS_BUILD_TYPE}" != "pull-request" ]] && ! rapids-is-stable-build; then
+if [[ "${RAPIDS_BUILD_TYPE}" != "pull-request" ]] && ! rapids-is-release-build; then
   VERSION_SUFFIX=$(date +%y%m%d)
   export VERSION_SUFFIX
 fi


### PR DESCRIPTION
`rapids-is-stable-build` was renamed to `rapids-is-release-build` in https://github.com/rapidsai/gha-tools/commit/5290fe5c25317821de06d11b2339d305fc78e258
We then also need to change the name in `rapids-env-update` to use this new name