### PR TITLE
Revert upload summary

### DIFF
--- a/tools/rapids-upload-to-s3
+++ b/tools/rapids-upload-to-s3
@@ -35,9 +35,4 @@ fi
 
 ARTIFACTS_URL=${browsable_url/s3:\/\/rapids-downloads\//https:\/\/downloads.rapids.ai\/}
 
-if [ -f "${GITHUB_STEP_SUMMARY}" ]; then
-  echo "## Artifacts URL" >> "${GITHUB_STEP_SUMMARY}"
-  echo "${ARTIFACTS_URL}" >> "${GITHUB_STEP_SUMMARY}"
-fi
-
 rapids-echo-stderr "${echo_prefix}Browse uploads: ${ARTIFACTS_URL}"


### PR DESCRIPTION
This PR reverts some changes from #9. Since we had to restrict downloads.rapids.ai to be VPN-accessible only, it doesn't make sense to broadcast the URL so prominently anymore. Also, it was a bit cluttersome that the same summary card was being created for every matrix variant in our builds.