### PR TITLE
Fix `rapids-upload-to-anaconda`

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+source-path=tools
+external-sources=true

--- a/tools/rapids-constants
+++ b/tools/rapids-constants
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export RAPIDS_DOWNLOADS_BUCKET="rapids-downloads"

--- a/tools/rapids-s3-path
+++ b/tools/rapids-s3-path
@@ -14,6 +14,7 @@
 ## For nightly builds:
 ## s3://rapids-downloads/nightly/<REPO_NAME>/<DATE>/<SHORT_HASH>/
 set -eo pipefail
+source rapids-constants
 
 echo_prefix="    [rapids-s3-path] "
 
@@ -63,7 +64,7 @@ esac
 
 short_hash=${RAPIDS_SHA:0:7}
 
-s3_path="s3://rapids-downloads/${s3_prefix}/${repo_name}/"
+s3_path="s3://${RAPIDS_DOWNLOADS_BUCKET}/${s3_prefix}/${repo_name}/"
 if [[ "${RAPIDS_BUILD_TYPE}" != "nightly" ]]; then
   s3_path+="${RAPIDS_BUILD_TYPE}/"
 fi

--- a/tools/rapids-s3-path
+++ b/tools/rapids-s3-path
@@ -18,20 +18,20 @@ source rapids-constants
 
 echo_prefix="    [rapids-s3-path] "
 
-if [[ ! -v RAPIDS_BUILD_TYPE ]]; then
-  rapids-echo-stderr "${echo_prefix}Env var RAPIDS_BUILD_TYPE must be set"
-  exit 1
-fi
+REQUIRED_ENV_VARS=(
+  "RAPIDS_BUILD_TYPE"
+  "RAPIDS_SHA"
+  "RAPIDS_REPOSITORY"
+  "RAPIDS_REF_NAME"
+)
 
-if [[ ! -v RAPIDS_SHA ]]; then
-  rapids-echo-stderr "${echo_prefix}Env var RAPIDS_SHA must be set"
-  exit 1
-fi
+for VAR in "${REQUIRED_ENV_VARS[@]}"; do
+  if [[ -z "${!VAR}" ]]; then
+    rapids-echo-stderr "${echo_prefix}Env var ${VAR} must be set"
+    exit 1
+  fi
+done
 
-if [[ ! -v RAPIDS_REPOSITORY ]]; then
-  rapids-echo-stderr "${echo_prefix}Env var RAPIDS_REPOSITORY must be set"
-  exit 1
-fi
 
 repo_name="${RAPIDS_REPOSITORY##*/}"
 

--- a/tools/rapids-upload-to-anaconda
+++ b/tools/rapids-upload-to-anaconda
@@ -1,32 +1,13 @@
 #!/bin/bash
-# A utility script that find all of the conda packages within a folder and
-# uploads them to Anaconda.org
-# Positional Arguments:
-#   1) a directory path to search for conda packages
+# A utility script that uploads all the conda packages from a
+# GitHub Actions workflow run to Anaconda.org
 set -e
+source rapids-constants
 
 echo_prefix="    [rapids-upload-to-anaconda] "
-search_dir="$1"
-
-if [ -z "${search_dir}" ]; then
-  rapids-echo-stderr "${echo_prefix}Please provide a search directory."
-  exit 1
-fi
 
 if [ ! -v RAPIDS_CONDA_TOKEN ] || [ -z "${RAPIDS_CONDA_TOKEN}" ]; then
   rapids-echo-stderr "${echo_prefix}Env var RAPIDS_CONDA_TOKEN must be set and not empty"
-  exit 1
-fi
-
-if [ ! -d "${search_dir}" ]; then
-  rapids-echo-stderr "${echo_prefix}Directory ${search_dir} does not exist."
-  exit 1
-fi
-
-pkgs_to_upload=$(find "${search_dir}" -name "*.tar.bz2")
-if [ -z "${pkgs_to_upload}" ]; then
-  rapids-echo-stderr "${echo_prefix}Couldn't find any packages to upload in: ${search_dir}."
-  ls -l "${search_dir}/"*
   exit 1
 fi
 
@@ -41,12 +22,50 @@ case "${RAPIDS_BUILD_TYPE}" in
     ;;
 esac
 
-rapids-echo-stderr "${echo_prefix}Uploading packages to Anaconda.org: ${pkgs_to_upload}"
-# shellcheck disable=SC2086
-anaconda \
-  -t "${RAPIDS_CONDA_TOKEN}" \
-  upload \
-  --label "${RAPIDS_CONDA_UPLOAD_LABEL:-main}" \
-  --skip-existing \
-  --no-progress \
-  ${pkgs_to_upload}
+
+S3_PATH=$(rapids-s3-path)
+BUCKET_PREFIX=${S3_PATH/s3:\/\/${RAPIDS_DOWNLOADS_BUCKET}\//} # removes s3://rapids-downloads/ from s3://rapids-downloads/ci/rmm/...
+
+export CONDA_ARTIFACTS=$(
+  aws \
+    --output json \
+    s3api list-objects \
+    --bucket "${RAPIDS_DOWNLOADS_BUCKET}" \
+    --prefix "${BUCKET_PREFIX}" \
+    --page-size 100 \
+    --query 'Contents[?contains(Key, `conda`)].Key' \
+    | jq -c
+)
+
+for OBJ in $(jq -nr 'env.CONDA_ARTIFACTS | fromjson | .[]'); do
+  FILENAME=$(basename "${OBJ}")
+  FILENAME_NO_EXT="${FILENAME%%.*}"
+  S3_URI="${S3_PATH}${FILENAME}"
+  UNTAR_DEST="${FILENAME_NO_EXT}"
+
+  rapids-echo-stderr "${echo_prefix}Untarring ${S3_URI} into ${UNTAR_DEST}"
+  mkdir -p "${UNTAR_DEST}"
+  aws s3 cp --only-show-errors "${S3_URI}" - | tar xzf - -C "${UNTAR_DEST}"
+
+  # don't upload tests packages (e.g. librmm-tests)
+  PKGS_TO_UPLOAD=$(find "${UNTAR_DEST}" -name "*.tar.bz2" ! -name "*-tests-*")
+
+  if [ -z "${PKGS_TO_UPLOAD}" ]; then
+    rapids-echo-stderr "${echo_prefix}Couldn't find any packages to upload in: ${UNTAR_DEST}."
+    tree "${UNTAR_DEST}/"*
+    exit 1
+  fi
+
+  rapids-echo-stderr "${echo_prefix}Uploading packages to Anaconda.org: ${PKGS_TO_UPLOAD}"
+
+  # shellcheck disable=SC2086
+  anaconda \
+    -t "${RAPIDS_CONDA_TOKEN}" \
+    upload \
+    --label "${RAPIDS_CONDA_UPLOAD_LABEL:-main}" \
+    --skip-existing \
+    --no-progress \
+    ${PKGS_TO_UPLOAD}
+
+  echo ""
+done

--- a/tools/rapids-upload-to-anaconda
+++ b/tools/rapids-upload-to-anaconda
@@ -26,7 +26,8 @@ esac
 S3_PATH=$(rapids-s3-path)
 BUCKET_PREFIX=${S3_PATH/s3:\/\/${RAPIDS_DOWNLOADS_BUCKET}\//} # removes s3://rapids-downloads/ from s3://rapids-downloads/ci/rmm/...
 
-export CONDA_ARTIFACTS=$(
+# shellcheck disable=SC2016
+CONDA_ARTIFACTS=$(
   aws \
     --output json \
     s3api list-objects \
@@ -36,6 +37,7 @@ export CONDA_ARTIFACTS=$(
     --query 'Contents[?contains(Key, `conda`)].Key' \
     | jq -c
 )
+export CONDA_ARTIFACTS
 
 for OBJ in $(jq -nr 'env.CONDA_ARTIFACTS | fromjson | .[]'); do
   FILENAME=$(basename "${OBJ}")

--- a/tools/rapids-upload-to-s3
+++ b/tools/rapids-upload-to-s3
@@ -4,6 +4,7 @@
 #   1) package name
 #   2) path to tar up
 set -eo pipefail
+source rapids-constants
 
 echo_prefix="    [rapids-upload-to-s3] "
 
@@ -33,6 +34,6 @@ else
   exit 1
 fi
 
-ARTIFACTS_URL=${browsable_url/s3:\/\/rapids-downloads\//https:\/\/downloads.rapids.ai\/}
+ARTIFACTS_URL=${browsable_url/s3:\/\/${RAPIDS_DOWNLOADS_BUCKET}\//https:\/\/downloads.rapids.ai\/}
 
 rapids-echo-stderr "${echo_prefix}Browse uploads: ${ARTIFACTS_URL}"


### PR DESCRIPTION
The existing implementation of `rapids-upload-to-anaconda` only uploads packages for a given directory. This PR changes its implementation to download all of the built `conda` packages from the current workflow (regardless of arch, Python version, etc.) and uploads them to Anaconda.org. This new implementation also skips uploading `*-tests-*` packages (e.g. `librmm-tests-22.10.00a220929-cuda11_g1fddc7bf_27.tar.bz2`)

A few other changes were included:

- `tools/rapids-s3-path` - refactored the required environment variable handling for this script to make it less verbose. and added `RAPIDS_REF_NAME` as a required env var since it was missing
- added `rapids-constants`, which can be sourced by other scripts to declare constant values like the `rapids-downloads` bucket name
- added a `.shellcheckrc` file

One final note is that due to https://github.com/aws/aws-cli/issues/709, I had to use `aws s3api list-objects` instead of `aws s3 ls`.