### PR TITLE
Use environment variable for nightly build dates

### DIFF
--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -26,8 +26,7 @@
 #                                Default is a 10 second sleep
 #
 set -o pipefail
-
-echo_prefix="    [rapids-conda-retry] "
+export RAPIDS_SCRIPT_NAME="rapids-conda-retry"
 
 condaretry_help="
 rapids-conda-retry options:
@@ -76,7 +75,7 @@ function runConda {
 
     if (( exitcode != 0 )); then
         # Show exit code
-        rapids-echo-stderr "${echo_prefix}conda returned exit code: ${exitcode}"
+        rapids-echo-stderr "conda returned exit code: ${exitcode}"
 
         if grep -q CondaHTTPError: "${outfile}"; then
             retryingMsg="Retrying, found 'CondaHTTPError:' in output..."
@@ -107,7 +106,7 @@ function runConda {
             retryingMsg="Retrying, found 'Timeout was reached' in output..."
             needToRetry=1
         else
-            rapids-echo-stderr "${echo_prefix}Exiting, no retryable ${RAPIDS_CONDA_EXE} errors detected: \
+            rapids-echo-stderr "Exiting, no retryable ${RAPIDS_CONDA_EXE} errors detected: \
 'ChecksumMismatchError:', \
 'ChunkedEncodingError:', \
 'CondaHTTPError:', \
@@ -122,12 +121,12 @@ function runConda {
         if (( needToRetry == 1 )) && \
            (( retries >= max_retries )); then
             # Catch instance where we run out of retries
-            rapids-echo-stderr "${echo_prefix}Exiting, reached max retries..."
+            rapids-echo-stderr "Exiting, reached max retries..."
         else
             # Give reason for retry
-            rapids-echo-stderr "${echo_prefix}${retryingMsg}"
+            rapids-echo-stderr "${retryingMsg}"
             if (( needToClean == 1 )); then
-                rapids-echo-stderr "${echo_prefix}Cleaning tarball cache before retrying..."
+                rapids-echo-stderr "Cleaning tarball cache before retrying..."
                 ${condaCmd} clean --tarballs -y
             fi
         fi
@@ -162,9 +161,9 @@ while (( needToRetry == 1 )) && \
       (( retries < max_retries )); do
 
    retries=$(( retries + 1 ))
-   rapids-echo-stderr "${echo_prefix}Waiting, retry ${retries} of ${max_retries} -> sleeping for ${sleep_interval} seconds..."
+   rapids-echo-stderr "Waiting, retry ${retries} of ${max_retries} -> sleeping for ${sleep_interval} seconds..."
    sleep "${sleep_interval}"
-   rapids-echo-stderr "${echo_prefix}Starting, retry ${retries} of ${max_retries} -> sleep done..."
+   rapids-echo-stderr "Starting, retry ${retries} of ${max_retries} -> sleep done..."
 
    # shellcheck disable=SC2086
    runConda ${args}

--- a/tools/rapids-download-from-s3
+++ b/tools/rapids-download-from-s3
@@ -5,11 +5,10 @@
 #   1) package name to generate s3 path for
 #   2) location to untar it to
 set -eo pipefail
-
-echo_prefix="    [rapids-download-from-s3] "
+export RAPIDS_SCRIPT_NAME="rapids-download-from-s3"
 
 if [ -z "$1" ] || [ -z "$2" ]; then
-  rapids-echo-stderr "${echo_prefix}Must specify input arguments: PKG_NAME and UNTAR_DEST"
+  rapids-echo-stderr "Must specify input arguments: PKG_NAME and UNTAR_DEST"
   exit 1
 fi
 
@@ -18,7 +17,7 @@ s3_dl_path="$(rapids-s3-path)$1"
 untar_dest="$2"
 mkdir -p "${untar_dest}"
 
-rapids-echo-stderr "${echo_prefix}Downloading and decompressing ${s3_dl_path} into ${untar_dest}"
+rapids-echo-stderr "Downloading and decompressing ${s3_dl_path} into ${untar_dest}"
 aws s3 cp --only-show-errors "${s3_dl_path}" - | tar xzf - -C "${untar_dest}"
 
 # echo path to untarred contents

--- a/tools/rapids-echo-stderr
+++ b/tools/rapids-echo-stderr
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 
 # Echo to stderr helper function
-echo "$*" >&2
+STR=""
+if [[ -n "${RAPIDS_SCRIPT_NAME}" ]]; then
+  STR+="    [${RAPIDS_SCRIPT_NAME}] "
+fi
+STR+="$*"
+
+echo "${STR}" >&2

--- a/tools/rapids-is-release-build
+++ b/tools/rapids-is-release-build
@@ -6,12 +6,11 @@
 # Example:
 #    if rapids-is-release-build; then echo "hi"; fi
 set -e
-
-echo_prefix="    [rapids-is-release-build]"
+export RAPIDS_SCRIPT_NAME="rapids-is-release-build"
 
 if [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9]{2}.[0-9]{2}.[0-9]{2}$ ]]; then
-  rapids-echo-stderr "${echo_prefix} is release build"
+  rapids-echo-stderr "is release build"
   exit 0
 fi
-rapids-echo-stderr "${echo_prefix} is not release build"
+rapids-echo-stderr "is not release build"
 exit 1

--- a/tools/rapids-package-name
+++ b/tools/rapids-package-name
@@ -4,13 +4,12 @@
 #   1) package type
 set -eo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-package-name"
-echo_prefix="    [${RAPIDS_SCRIPT_NAME}] "
 
 rapids-require-env-var "RAPIDS_REPOSITORY"
 repo_name="${RAPIDS_REPOSITORY##*/}"
 
 if [ -z "$1" ]; then
-  rapids-echo-stderr "${echo_prefix}Must specify input arguments: PKG_TYPE"
+  rapids-echo-stderr "Must specify input arguments: PKG_TYPE"
   exit 1
 fi
 
@@ -30,7 +29,7 @@ case "${pkg_type}" in
     append_wheelname=1
     ;;
   *)
-    rapids-echo-stderr "${echo_prefix}Nonstandard package type '${pkg_type}'"
+    rapids-echo-stderr "Nonstandard package type '${pkg_type}'"
     exit 1
     ;;
 esac

--- a/tools/rapids-package-name
+++ b/tools/rapids-package-name
@@ -3,13 +3,10 @@
 # Positional Arguments:
 #   1) package type
 set -eo pipefail
+export RAPIDS_SCRIPT_NAME="rapids-package-name"
+echo_prefix="    [${RAPIDS_SCRIPT_NAME}] "
 
-echo_prefix="    [rapids-package-name] "
-
-if [[ ! -v RAPIDS_REPOSITORY ]]; then
-    rapids-echo-stderr "${echo_prefix}Env var RAPIDS_REPOSITORY must be set"
-    exit 1
-fi
+rapids-require-env-var "RAPIDS_REPOSITORY"
 repo_name="${RAPIDS_REPOSITORY##*/}"
 
 if [ -z "$1" ]; then
@@ -47,11 +44,7 @@ fi
 
 # for python package types, add pyver
 if (( append_pyver == 1 )); then
-  if [[ ! -v RAPIDS_PY_VERSION ]]; then
-    rapids-echo-stderr "${echo_prefix}Env var RAPIDS_PY_VERSION must be set"
-    exit 1
-  fi
-
+  rapids-require-env-var "RAPIDS_PY_VERSION"
   pkg_name+="_${RAPIDS_PY_VERSION//./}"
 fi
 

--- a/tools/rapids-require-env-var
+++ b/tools/rapids-require-env-var
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Helper function that will exit with a non-zero code if the provided
+# environment variable is not set.
+# Note: Pass the environment variable's name as a string (e.g. "HOME"),
+# not it's value (e.g. "$HOME").
+# Usage:
+#   rapids-require-env-var "RAPIDS_BUILD_TYPE"
+set -e
+
+ENV_VAR_NAME=$1
+
+if [[ -z "${!ENV_VAR_NAME}" ]]; then
+  ERR_STR="${ENV_VAR_NAME} is a required environment variable"
+
+  if [[ -n "${RAPIDS_SCRIPT_NAME}" ]]; then
+    ERR_STR+=" for [${RAPIDS_SCRIPT_NAME}]"
+  fi
+
+  echo "${ERR_STR}"
+  exit 1
+fi

--- a/tools/rapids-s3-path
+++ b/tools/rapids-s3-path
@@ -53,7 +53,7 @@ case "${RAPIDS_BUILD_TYPE}" in
     s3_prefix="ci"
     ;;
   nightly)
-    s3_directory_id="$(date +%F)"
+    s3_directory_id="${RAPIDS_NIGHTLY_DATE}"
     s3_prefix="nightly"
     ;;
   *)

--- a/tools/rapids-s3-path
+++ b/tools/rapids-s3-path
@@ -15,23 +15,11 @@
 ## s3://rapids-downloads/nightly/<REPO_NAME>/<DATE>/<SHORT_HASH>/
 set -eo pipefail
 source rapids-constants
+export RAPIDS_SCRIPT_NAME="rapids-s3-path"
 
-echo_prefix="    [rapids-s3-path] "
-
-REQUIRED_ENV_VARS=(
-  "RAPIDS_BUILD_TYPE"
-  "RAPIDS_SHA"
-  "RAPIDS_REPOSITORY"
-  "RAPIDS_REF_NAME"
-)
-
-for VAR in "${REQUIRED_ENV_VARS[@]}"; do
-  if [[ -z "${!VAR}" ]]; then
-    rapids-echo-stderr "${echo_prefix}Env var ${VAR} must be set"
-    exit 1
-  fi
-done
-
+rapids-require-env-var "RAPIDS_BUILD_TYPE"
+rapids-require-env-var "RAPIDS_SHA"
+rapids-require-env-var "RAPIDS_REPOSITORY"
 
 repo_name="${RAPIDS_REPOSITORY##*/}"
 
@@ -45,14 +33,17 @@ case "${RAPIDS_BUILD_TYPE}" in
     # more info:
     #    CopyPRs plugin in ops-bot: https://github.com/rapidsai/ops-bot#plugins
     #    https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
+    rapids-require-env-var "RAPIDS_REF_NAME"
     s3_directory_id="${RAPIDS_REF_NAME##*/}"
     s3_prefix="ci"
     ;;
   branch)
+    rapids-require-env-var "RAPIDS_REF_NAME"
     s3_directory_id="${RAPIDS_REF_NAME}"
     s3_prefix="ci"
     ;;
   nightly)
+    rapids-require-env-var "RAPIDS_NIGHTLY_DATE"
     s3_directory_id="${RAPIDS_NIGHTLY_DATE}"
     s3_prefix="nightly"
     ;;

--- a/tools/rapids-size-checker
+++ b/tools/rapids-size-checker
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 export RAPIDS_SCRIPT_NAME="rapids-size-checker"
-echo_prefix="    [${RAPIDS_SCRIPT_NAME}] "
 
 rapids-require-env-var "RAPIDS_GH_TOKEN"
 

--- a/tools/rapids-size-checker
+++ b/tools/rapids-size-checker
@@ -1,12 +1,9 @@
 #!/bin/bash
 set -e
+export RAPIDS_SCRIPT_NAME="rapids-size-checker"
+echo_prefix="    [${RAPIDS_SCRIPT_NAME}] "
 
-echo_prefix="    [rapids-size-checker] "
-
-if [ ! -v RAPIDS_GH_TOKEN ] || [ -z "${RAPIDS_GH_TOKEN}" ]; then
-  rapids-echo-stderr "${echo_prefix}Env var RAPIDS_GH_TOKEN must be set and not empty"
-  exit 1
-fi
+rapids-require-env-var "RAPIDS_GH_TOKEN"
 
 echo "Retrieving base branch from GitHub API:"
 # For PRs, the branch name is like:

--- a/tools/rapids-upload-to-anaconda
+++ b/tools/rapids-upload-to-anaconda
@@ -3,13 +3,10 @@
 # GitHub Actions workflow run to Anaconda.org
 set -e
 source rapids-constants
+export RAPIDS_SCRIPT_NAME="rapids-upload-to-anaconda"
+echo_prefix="    [${RAPIDS_SCRIPT_NAME}] "
 
-echo_prefix="    [rapids-upload-to-anaconda] "
-
-if [ ! -v RAPIDS_CONDA_TOKEN ] || [ -z "${RAPIDS_CONDA_TOKEN}" ]; then
-  rapids-echo-stderr "${echo_prefix}Env var RAPIDS_CONDA_TOKEN must be set and not empty"
-  exit 1
-fi
+rapids-require-env-var "RAPIDS_CONDA_TOKEN"
 
 case "${RAPIDS_BUILD_TYPE}" in
   branch)

--- a/tools/rapids-upload-to-anaconda
+++ b/tools/rapids-upload-to-anaconda
@@ -4,7 +4,6 @@
 set -e
 source rapids-constants
 export RAPIDS_SCRIPT_NAME="rapids-upload-to-anaconda"
-echo_prefix="    [${RAPIDS_SCRIPT_NAME}] "
 
 rapids-require-env-var "RAPIDS_CONDA_TOKEN"
 
@@ -14,7 +13,7 @@ case "${RAPIDS_BUILD_TYPE}" in
   nightly)
     ;;
   *)
-    rapids-echo-stderr "${echo_prefix}Only branch builds and nightly builds are uploaded to Anaconda.org"
+    rapids-echo-stderr "Only branch builds and nightly builds are uploaded to Anaconda.org"
     exit 1
     ;;
 esac
@@ -42,7 +41,7 @@ for OBJ in $(jq -nr 'env.CONDA_ARTIFACTS | fromjson | .[]'); do
   S3_URI="${S3_PATH}${FILENAME}"
   UNTAR_DEST="${FILENAME_NO_EXT}"
 
-  rapids-echo-stderr "${echo_prefix}Untarring ${S3_URI} into ${UNTAR_DEST}"
+  rapids-echo-stderr "Untarring ${S3_URI} into ${UNTAR_DEST}"
   mkdir -p "${UNTAR_DEST}"
   aws s3 cp --only-show-errors "${S3_URI}" - | tar xzf - -C "${UNTAR_DEST}"
 
@@ -50,12 +49,12 @@ for OBJ in $(jq -nr 'env.CONDA_ARTIFACTS | fromjson | .[]'); do
   PKGS_TO_UPLOAD=$(find "${UNTAR_DEST}" -name "*.tar.bz2" ! -name "*-tests-*")
 
   if [ -z "${PKGS_TO_UPLOAD}" ]; then
-    rapids-echo-stderr "${echo_prefix}Couldn't find any packages to upload in: ${UNTAR_DEST}."
+    rapids-echo-stderr "Couldn't find any packages to upload in: ${UNTAR_DEST}."
     tree "${UNTAR_DEST}/"*
     exit 1
   fi
 
-  rapids-echo-stderr "${echo_prefix}Uploading packages to Anaconda.org: ${PKGS_TO_UPLOAD}"
+  rapids-echo-stderr "Uploading packages to Anaconda.org: ${PKGS_TO_UPLOAD}"
 
   # shellcheck disable=SC2086
   anaconda \

--- a/tools/rapids-upload-to-s3
+++ b/tools/rapids-upload-to-s3
@@ -5,11 +5,10 @@
 #   2) path to tar up
 set -eo pipefail
 source rapids-constants
-
-echo_prefix="    [rapids-upload-to-s3] "
+export RAPIDS_SCRIPT_NAME="rapids-upload-to-s3"
 
 if [ -z "$1" ] || [ -z "$2" ]; then
-  rapids-echo-stderr "${echo_prefix}Must specify both input arguments: PACKAGE_NAME and PATH_TO_TAR_UP"
+  rapids-echo-stderr "Must specify both input arguments: PACKAGE_NAME and PATH_TO_TAR_UP"
   exit 1
 fi
 
@@ -17,23 +16,23 @@ path_to_tar_up="$2"
 s3_dest_path="$(rapids-s3-path)$1"
 
 if [ -d "${path_to_tar_up}" ]; then
-  rapids-echo-stderr "${echo_prefix}Path to upload is a directory, creating .tar.gz"
+  rapids-echo-stderr "Path to upload is a directory, creating .tar.gz"
 
   # Tar.gz to stdout and pipe that to the s3 command, no need for a local file
   tar czfv - -C "${path_to_tar_up}" . | aws s3 cp --only-show-errors - "${s3_dest_path}"
 
   browsable_url="$(dirname "${s3_dest_path}")/"
 elif [ -f "${path_to_tar_up}" ]; then
-  rapids-echo-stderr "${echo_prefix}Path to upload is a file, uploading it directly"
+  rapids-echo-stderr "Path to upload is a file, uploading it directly"
 
   aws s3 cp --only-show-errors "${path_to_tar_up}" "${s3_dest_path}"
 
   browsable_url="${s3_dest_path}"
 else
-  rapids-echo-stderr "${echo_prefix}Path '$path_to_tar_up' is not a directory or file"
+  rapids-echo-stderr "Path '$path_to_tar_up' is not a directory or file"
   exit 1
 fi
 
 ARTIFACTS_URL=${browsable_url/s3:\/\/${RAPIDS_DOWNLOADS_BUCKET}\//https:\/\/downloads.rapids.ai\/}
 
-rapids-echo-stderr "${echo_prefix}Browse uploads: ${ARTIFACTS_URL}"
+rapids-echo-stderr "Browse uploads: ${ARTIFACTS_URL}"


### PR DESCRIPTION
This PR includes a few changes, the majority of which are refactoring based on the introduction of a new `rapids-require-env-var` helper script, described below.

## Initial Problem

The current value of `s3_directory_id` for nightly builds is computed from the output of `$(date +%F)`. It's potentially problematic to use `date` to compute this value at runtime.

The potential problem arises from the fact that the `date` command can be run on several different machine types (e.g. ASELab nodes, EKS nodes, GitHub-hosted runner nodes, etc). 

There are no guarantees that the time zones for all of these machines are consistent.

Therefore it's entirely possible for the `date` command to return different values when it's run in a `build` vs. `test` script, especially given:

- our full `build` and `test` stages can take several hours to complete
- the nightly builds occur in the middle of the night, which has the most potential for the `date` function to return different date values

## Proposed Solution

Instead of using `date` to compute the nightly `s3_directory_id` value, we should get that value from a new environment variable, `RAPIDS_NIGHTLY_DATE`, which will be computed once at the top-level nightly workflow and passed down to relevant scripts.

To ensure that `RAPIDS_NIGHTLY_DATE` is set for nightly builds, a new helper function, `rapids-require-env-var`, was introduced.

## Refactor Changes

Existing scripts were refactored to use `rapids-require-env-var`.

Additionally, `rapids-echo-stderr` was refactored to use the same `RAPIDS_SCRIPT_NAME` variable used by `rapids-require-env-var`. `RAPIDS_SCRIPT_NAME` is a suitable replacement for the `echo_prefix` variable that commonly set throughout the scripts.