### PR TITLE
Add VPN note

### DIFF
--- a/tools/rapids-upload-to-s3
+++ b/tools/rapids-upload-to-s3
@@ -35,4 +35,4 @@ fi
 
 ARTIFACTS_URL=${browsable_url/s3:\/\/${RAPIDS_DOWNLOADS_BUCKET}\//https:\/\/downloads.rapids.ai\/}
 
-rapids-echo-stderr "Browse uploads: ${ARTIFACTS_URL}"
+rapids-echo-stderr "Browse uploads (NVIDIA Employee VPN Required): ${ARTIFACTS_URL}"


### PR DESCRIPTION
Since downloads.rapids.ai is no longer publicly viewable, this PR adds a small note to our log output to make it clear that the NVIDIA Employee VPN is required to access artifacts.