### PR TITLE
Replace `/tmp/conda-bld-output` w/ environment var

### DIFF
--- a/tools/rapids-upload-conda-to-s3
+++ b/tools/rapids-upload-conda-to-s3
@@ -1,5 +1,5 @@
 #!/bin/bash
-# A utility script that tars up `/tmp/conda-bld-output` and uploads it to S3
+# A utility script that tars up $RAPIDS_CONDA_BLD_OUTPUT_DIR and uploads it to S3
 # Positional Arguments:
 #   1) a string of "cpp" or "python" which determines which conda artifact
 #      should be uploaded
@@ -22,6 +22,7 @@ pkg_type="conda_$pkg_type"
 pkg_name="$(rapids-package-name "$pkg_type")"
 
 # Where conda build artifacts are output
-path_to_tar_up="/tmp/conda-bld-output"
+rapids-require-env-var "RAPIDS_CONDA_BLD_OUTPUT_DIR"
+path_to_tar_up="${RAPIDS_CONDA_BLD_OUTPUT_DIR}"
 
 rapids-upload-to-s3 "${pkg_name}" "${path_to_tar_up}"


### PR DESCRIPTION
This PR replaces the hardcoded `/tmp/conda-bld-output` path with an environment variable which is defined in our CI Docker images.