### PR TITLE
Append CUDA version to conda packages

### DIFF
--- a/tools/rapids-package-name
+++ b/tools/rapids-package-name
@@ -15,13 +15,16 @@ fi
 
 pkg_type="$1"
 
+append_cuda=0
 append_pyver=0
 append_wheelname=0
 
 case "${pkg_type}" in
   conda_cpp)
+    append_cuda=1
     ;;
   conda_python)
+    append_cuda=1
     append_pyver=1
     ;;
   wheel_python)
@@ -35,6 +38,12 @@ case "${pkg_type}" in
 esac
 
 pkg_name="${pkg_type}"
+
+# for conda package types, append CUDA version
+if (( append_cuda == 1 )); then
+  rapids-require-env-var "RAPIDS_CUDA_VERSION"
+  pkg_name+="_cuda${RAPIDS_CUDA_VERSION%%.*}"
+fi
 
 # for wheels, add the python wheel name if env var is set
 if (( append_wheelname )) && [[ -v RAPIDS_PY_WHEEL_NAME ]] && [[ "${RAPIDS_PY_WHEEL_NAME}" != "" ]]; then


### PR DESCRIPTION
We need to add CUDA version to conda package names so we can upload both CUDA 11 and 12 packages without conflict on the name. This will append `cuda11` or `cuda12`