### PR TITLE
Update `rapids-dependency-file-checker`

### DIFF
--- a/tools/rapids-dependency-file-checker
+++ b/tools/rapids-dependency-file-checker
@@ -12,7 +12,7 @@ grep -rlP \
   --include="*.txt" \
   --include="*.yaml" \
   "${SEARCH_PATTERN}" . | \
-  xargs rm
+  xargs rm || true
 
 rapids-dependency-file-generator --config "${CONFIG_FILE:-"dependencies.yaml"}"
 


### PR DESCRIPTION
This PR updates `rapids-dependency-file-checker` to ensure that it exits with a zero code if there are no existing generated dependency files that need to be deleted.

This became in issue in `rapids-cmake` since that repository uses a `dependencies.yaml` file, but does not write any files to the repository (e.g. there are no `conda/environments/*` files that are generated).

The error message can be seen in the GitHub Action log below for https://github.com/rapidsai/rapids-cmake/pull/283.

- https://github.com/rapidsai/rapids-cmake/actions/runs/3396159139/jobs/5646913087