### PR TITLE
Update `rapids-upload-to-anaconda` Error Handling

### DIFF
--- a/tools/rapids-upload-to-anaconda
+++ b/tools/rapids-upload-to-anaconda
@@ -1,7 +1,7 @@
 #!/bin/bash
 # A utility script that uploads all the conda packages from a
 # GitHub Actions workflow run to Anaconda.org
-set -e
+set -eo pipefail
 source rapids-constants
 export RAPIDS_SCRIPT_NAME="rapids-upload-to-anaconda"
 
@@ -24,6 +24,7 @@ BUCKET_PREFIX=${S3_PATH/s3:\/\/${RAPIDS_DOWNLOADS_BUCKET}\//} # removes s3://rap
 
 # shellcheck disable=SC2016
 CONDA_ARTIFACTS=$(
+  set -eo pipefail;
   aws \
     --output json \
     s3api list-objects \


### PR DESCRIPTION
In a recent GitHub Actions run ([link](https://github.com/rapidsai/rapids-cmake/actions/runs/3413106288/jobs/5679670752#step:6:11)), the `rapids-upload-to-anaconda` script failed due to missing AWS credentials. However, since the bash error handling wasn't configured properly, the GH Action run was reported as a success.

This PR updates the script to ensure that this issue doesn't happen again.

Note that `inherit_errexit` ([link](https://saveriomiroddi.github.io/Additional-shell-options-for-non-trivial-bash-shell-scripts/#inherit_errexit)) would also work for this use case, but it's only supported on `bash` versions `4.4+` and `centos7` has `bash` version `4.2`. So that option was skipped for this situation since some of our containers are `centos7` based.