### PR TITLE
Add `rapids-check-pr-job-dependencies` script

### DIFF
--- a/tools/rapids-check-pr-job-dependencies
+++ b/tools/rapids-check-pr-job-dependencies
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Checks whether a particular GitHub workflow job depends on all of the
+# other jobs in the workflow.
+#
+# This is necessary since the RAPIDS branch protections are configured to require
+# the "pr-builder" job to pass for all PRs. It's implied that that job depends
+# on all other jobs in the workflow.
+set -euo pipefail
+
+export WORKFLOW_FILE=${WORKFLOW_FILE:-".github/workflows/pr.yaml"}
+export PR_BUILDER_JOB_NAME=${PR_BUILDER_JOB_NAME:-"pr-builder"}
+
+WORKFLOW_JOBS=$(yq '((.jobs | keys | sort) - [env(PR_BUILDER_JOB_NAME)]) | join(" ")' "${WORKFLOW_FILE}")
+
+PR_BUILDER_JOB_NEEDS=$(yq '(.jobs.[env(PR_BUILDER_JOB_NAME)].needs | sort) | join(" ")' "${WORKFLOW_FILE}")
+
+if [ "${WORKFLOW_JOBS}" != "${PR_BUILDER_JOB_NEEDS}" ]; then
+  echo "'${PR_BUILDER_JOB_NAME}' is missing a dependency."
+  echo "Update '${WORKFLOW_FILE}' to include all other jobs for '${PR_BUILDER_JOB_NAME}'"
+  echo ""
+  echo "Workflow jobs: ${WORKFLOW_JOBS}"
+  echo "'${PR_BUILDER_JOB_NAME}' job dependencies: ${PR_BUILDER_JOB_NEEDS}"
+  exit 1
+fi
+
+echo "${PR_BUILDER_JOB_NAME} depends on all other jobs."

--- a/tools/rapids-retry
+++ b/tools/rapids-retry
@@ -39,7 +39,7 @@ function rapids-retry {
           (( retries < max_retries )); do
       ((retries++))
       rapids-logger "rapids-retry: retry ${retries} of ${max_retries} | exit code: (${retcode}) -> sleeping for ${sleep_interval} seconds..."
-      sleep ${sleep_interval}
+      sleep "${sleep_interval}"
       rapids-logger "rapids-retry: sleep done -> retrying..."
 
       ${command} "$@"


### PR DESCRIPTION
This PR adds a new script, `rapids-check-pr-job-dependencies`.

This script is intended to be used in a new check job in the `shared-action-workflows` repository.

The script checks the `pr-builder` job in the `pr.yaml` workflow file to ensure that it depends on all of the other jobs in the workflow file.

This is necessary because our branch protections are configured to depend on the `pr-builder` job, so it's implied that that job will depend on all of the other jobs in the workflow.

Depends on https://github.com/rapidsai/ci-imgs/pull/30.