### PR TITLE
Add `rapids-get-rapids-version-from-git`

### DIFF
--- a/tools/rapids-get-rapids-version-from-git
+++ b/tools/rapids-get-rapids-version-from-git
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Gets RAPIDS version from a git tag.
+# If `git describe` returns "v23.02.00a", then the
+# `sed` command will remove the alpha characters and
+# the `cut` command will return the first two fields,
+# resulting in "23.02".
+set -euo pipefail
+
+
+git describe --abbrev=0 --tags | sed 's/[a-zA-Z]//g' | cut -d '.' -f -2


### PR DESCRIPTION
This PR adds a new utility called `rapids-get-rapids-version-from-git` which will get the RAPIDS version from the latest `git` tag in a repo.