### PR TITLE
Add `rapids-get-artifact`

### DIFF
--- a/tools/rapids-get-artifact
+++ b/tools/rapids-get-artifact
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Downloads an artifact, extracts it to a directory, and
+# echoes the resulting directory's path
+# Positional Arguments:
+#   1) path to an artifact (e.g. ci/cudf/pull-request/12602/aa4da21/cudf_conda_python_cuda11_38_x86_64.tar.gz)
+# Example Usage:
+#   rapids-get-artifact ci/cudf/pull-request/12602/aa4da21/cudf_conda_python_cuda11_38_x86_64.tar.gz
+set -euo pipefail
+source rapids-constants
+
+artifact_path="s3://${RAPIDS_DOWNLOADS_BUCKET}/${1}"
+untar_dest=$(mktemp -d)
+
+rapids-echo-stderr "Downloading and decompressing ${artifact_path} into ${untar_dest}"
+aws s3 cp --only-show-errors "${artifact_path}" - | tar xzf - -C "${untar_dest}"
+
+echo -n "${untar_dest}"


### PR DESCRIPTION
This PR introduces a small new function, `rapids-get-artifact`.

Given an artifact path, it will:

- download the artifact
- extract the artifact to a temporary directory
- echo the location of the temporary directory

**Example Usage:**

```sh
CUDF_CHANNEL=$(rapids-get-artifact ci/cudf/pull-request/12602/aa4da21/cudf_conda_python_cuda11_38_x86_64.tar.gz)

echo "$CUDF_CHANNEL" # prints a dir name like "/tmp/tmp.4BnKNJyyQg"
```