### PR TITLE
Ensure `VERSION_SUFFIX` is added to PR artifacts

### DIFF
--- a/.github/workflows/prs.yaml
+++ b/.github/workflows/prs.yaml
@@ -9,6 +9,10 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,10 @@ on:
       - "tools/*"
       - ".github/workflows/release.yaml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     env:

--- a/tools/rapids-env-update
+++ b/tools/rapids-env-update
@@ -11,7 +11,7 @@ if rapids-is-release-build; then
 fi
 
 # If nightly or branch build, append current YYMMDD to version
-if [[ "${RAPIDS_BUILD_TYPE}" != "pull-request" ]] && ! rapids-is-release-build; then
+if ! rapids-is-release-build; then
   VERSION_SUFFIX=$(date +%y%m%d)
   export VERSION_SUFFIX
 fi


### PR DESCRIPTION
This change ensures that the `VERSION_SUFFIX` environment variable is available for pull-request builds.

This will ensure that pull-request and nightly packages can be installed in the same environment.

@bdice had some issues with this recently due to this discrepancy in pull-request vs. nightly packages versions.

In the long term, we should explore moving the `VERSION_SUFFIX` value to the build string of our conda packages rather than the version string since having the value in the version string can cause issues and is inconsistent with our stable build versions.