### PR TITLE
Add `DATE_STRING` environment variable for builds

### DIFF
--- a/tools/rapids-env-update
+++ b/tools/rapids-env-update
@@ -18,8 +18,8 @@ if [ "${CI:-false}" = "false" ]; then
   export RAPIDS_BUILD_TYPE=${RAPIDS_BUILD_TYPE:-"pull-request"}
 fi
 
-# If nightly or branch build, append current YYMMDD to version
+# TODO: Remove this conditional block after 23.02 release
 if ! rapids-is-release-build; then
   VERSION_SUFFIX=$(date +%y%m%d)
-  export VERSION_SUFFIX
+  export VERSION_SUFFIX DATE_STRING=$VERSION_SUFFIX
 fi


### PR DESCRIPTION
This PR adds the `DATE_STRING` environment variable which will be used in some upcoming conda recipe changes.

Assuming the changes work as intended, we should remove the conditional block of code and remove `VERSION_SUFFIX` in favor of `DATE_STRING` after the `23.02` release.