### PR TITLE
Use commit for date string & update var name

### DIFF
--- a/tools/rapids-env-update
+++ b/tools/rapids-env-update
@@ -20,6 +20,6 @@ fi
 
 # TODO: Remove this conditional block after 23.02 release
 if ! rapids-is-release-build; then
-  VERSION_SUFFIX=$(date +%y%m%d)
-  export VERSION_SUFFIX DATE_STRING=$VERSION_SUFFIX
+  VERSION_SUFFIX=$(git show --no-patch --date=format:'%y%m%d' --format='%cd')
+  export VERSION_SUFFIX RAPIDS_DATE_STRING=$VERSION_SUFFIX
 fi


### PR DESCRIPTION
@bdice pointed out that it's probably a better idea to get the date from the commit rather than arbitrarily calling the `date` function.

This PR adjusts that implementation accordingly.

It also updates the variable name from `DATE_STRING` to `RAPIDS_DATE_STRING` in accordance with our environment variable name conventions.