### PR TITLE
Update `rapids-is-release-build`

### DIFF
--- a/tools/rapids-is-release-build
+++ b/tools/rapids-is-release-build
@@ -8,7 +8,7 @@
 set -e
 export RAPIDS_SCRIPT_NAME="rapids-is-release-build"
 
-if [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9]{2}.[0-9]{2}.[0-9]{2}$ ]]; then
+if [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9]{1,2}.[0-9]{2}.[0-9]{2}$ ]]; then
   rapids-echo-stderr "is release build"
   exit 0
 fi


### PR DESCRIPTION
This PR updates `rapids-is-release-build` so that it accounts for release tags for `ucx-py`.

`ucx-py` releases tags look like:

```
refs/tags/v0.30.00
```

whereas RAPIDS release tags look like:

```
refs/tags/v23.02.00
```