### PR TITLE
Remove conditional on `RAPIDS_DATE_STRING`

### DIFF
--- a/tools/rapids-env-update
+++ b/tools/rapids-env-update
@@ -18,8 +18,5 @@ if [ "${CI:-false}" = "false" ]; then
   export RAPIDS_BUILD_TYPE=${RAPIDS_BUILD_TYPE:-"pull-request"}
 fi
 
-# TODO: Remove this conditional block after 23.02 release
-if ! rapids-is-release-build; then
-  VERSION_SUFFIX=$(git show --no-patch --date=format:'%y%m%d' --format='%cd')
-  export VERSION_SUFFIX RAPIDS_DATE_STRING=$VERSION_SUFFIX
-fi
+VERSION_SUFFIX=$(git show --no-patch --date=format:'%y%m%d' --format='%cd')
+export VERSION_SUFFIX RAPIDS_DATE_STRING=$VERSION_SUFFIX


### PR DESCRIPTION
We need to remove this conditional since all builds in RAPIDS (branch & release) require `RAPIDS_DATE_STRING` now.

See: https://github.com/rapidsai/rmm/actions/runs/4678847102/jobs/8288079290#step:7:432