### PR TITLE
Add scripts for assembling docker multiarch manifests from a local registry

### DIFF
--- a/tools/rapids-docker-multiarch-from-s3
+++ b/tools/rapids-docker-multiarch-from-s3
@@ -62,7 +62,7 @@ for OBJ in $(jq -nr 'env.DOCKER_TARBALLS | fromjson | .[]'); do
   MULTIARCH_IMAGES["${multiarch_tag}"]+=" ${loaded_image}"
 done
 
-manifests_to_push=()
+manifests_to_copy=()
 
 for key in "${!MULTIARCH_IMAGES[@]}"; do
   values="${MULTIARCH_IMAGES[$key]}"
@@ -77,16 +77,22 @@ for key in "${!MULTIARCH_IMAGES[@]}"; do
     manifest_args+="--amend ${local_name} "
   done
 
+  local_manifest="localhost:5000/${key}"
+
   # shellcheck disable=SC2086
-  docker manifest create --insecure "${key}" ${manifest_args} 1>&2
-  manifests_to_push+=("${key}")
+  docker manifest create --insecure "${local_manifest}" ${manifest_args} 1>&2
+  docker manifest push "${local_manifest}"
+  manifests_to_copy+=("${local_manifest}")
 
   # if latest tags have been supplied this image matches the latest, give it the additional latest tag
   if [ -n "${latest_tag}" ] && [ -n "${latest_tag_alias}" ] && [ "${key}" == "${latest_tag}" ]; then
+    local_latest="localhost:5000/${latest_tag_alias}"
+
     # shellcheck disable=SC2086
-    docker manifest create --insecure "${latest_tag_alias}" ${manifest_args} 1>&2
-    manifests_to_push+=("${latest_tag_alias}")
+    docker manifest create --insecure "${local_latest}" ${manifest_args} 1>&2
+    docker manifest push "${local_latest}"
+    manifests_to_copy+=("${local_latest}")
   fi
 done
 
-echo -n "${manifests_to_push[@]}"
+echo -n "${manifests_to_copy[@]}"

--- a/tools/rapids-docker-multiarch-from-s3
+++ b/tools/rapids-docker-multiarch-from-s3
@@ -1,0 +1,55 @@
+#!/bin/bash
+# A utility script that downloads all docker images from S3
+# and assembles them into multiarch tags
+set -eo pipefail
+source rapids-constants
+export RAPIDS_SCRIPT_NAME="rapids-docker-multiarch-from-s3"
+
+DOCKER_TMP_DIR="$(mktemp -d)"
+
+DOCKER_STARTS_WITH="docker_"
+DOCKER_ENDS_WITH=".tar.gz"
+
+S3_PATH=$(rapids-s3-path)
+BUCKET_PREFIX=${S3_PATH/s3:\/\/${RAPIDS_DOWNLOADS_BUCKET}\//} # removes s3://rapids-downloads/ from s3://rapids-downloads/ci/rmm/...
+
+# shellcheck disable=SC2016
+DOCKER_TARBALLS=$(
+  set -eo pipefail;
+  aws \
+    --output json \
+    s3api list-objects \
+    --bucket "${RAPIDS_DOWNLOADS_BUCKET}" \
+    --prefix "${BUCKET_PREFIX}" \
+    --page-size 100 \
+    --query "Contents[?starts_with(Key, '${DOCKER_STARTS_WITH}') && ends_with(Key, '${DOCKER_ENDS_WITH}')].Key" \
+    | jq -c
+)
+export DOCKER_TARBALLS
+
+# create an associative array (i.e. dict) of multiarch image to per-arch image
+declare -A MULTIARCH_IMAGES
+
+# download and load them all
+for OBJ in $(jq -nr 'env.DOCKER_TARBALLS | fromjson | .[]'); do
+  FILENAME=$(basename "${OBJ}")
+  S3_URI="${S3_PATH}${FILENAME}"
+
+  rapids-echo-stderr "Downloading ${S3_URI} into ${DOCKER_TMP_DIR}"
+  aws s3 cp --only-show-errors "${S3_URI}" "${DOCKER_TMP_DIR}"/
+
+  rapids-echo-stderr "Loading into docker"
+  loaded_image=$(docker load < "${DOCKER_TMP_DIR}/${FILENAME}")
+  loaded_image="${loaded_image/"Loaded image: "/}"
+
+  # strip architecture hyphen
+  loaded_image_no_arch="${loaded_image_no_arch/"-x86_64"/}"
+  loaded_image_no_arch="${loaded_image_no_arch/"-aarch64"/}"
+
+  # no-arch tag is the final multiarch tag
+  multiarch_tag="${loaded_image_no_arch}"
+
+  MULTIARCH_IMAGES[${multiarch_tag}]+="${loaded_image}"
+done
+
+echo "${MULTIARCH_IMAGES}"

--- a/tools/rapids-docker-multiarch-from-s3
+++ b/tools/rapids-docker-multiarch-from-s3
@@ -49,6 +49,9 @@ for OBJ in $(jq -nr 'env.DOCKER_TARBALLS | fromjson | .[]'); do
   loaded_image=$(docker load < "${DOCKER_TMP_DIR}/${FILENAME}")
   loaded_image="${loaded_image/"Loaded image: "/}"
 
+  # delete the tarball to save space
+  rm "${DOCKER_TMP_DIR}/${FILENAME}" 1>&2
+
   # strip -$(uname -m) or amd64 or arm64
   loaded_image_no_arch="${loaded_image/"-x86_64"/}"
   loaded_image_no_arch="${loaded_image_no_arch/"-aarch64"/}"

--- a/tools/rapids-docker-multiarch-from-s3
+++ b/tools/rapids-docker-multiarch-from-s3
@@ -65,16 +65,13 @@ for OBJ in $(jq -nr 'env.DOCKER_TARBALLS | fromjson | .[]'); do
   MULTIARCH_IMAGES["${multiarch_tag}"]+=" ${loaded_image}"
 done
 
-# start a local registry
-rapids-echo-stderr "Starting local registry"
-docker run -d -p 5000:5000 --restart=always --name tmp-registry registry:2
-
 for key in "${!MULTIARCH_IMAGES[@]}"; do
   values="${MULTIARCH_IMAGES[$key]}"
   rapids-echo-stderr "Preparing multiarch manifest for: ${key} with per-arch images: ${values}"
 
   manifest_args=""
   for value in ${values}; do
+    # use the local registry set up by the `service` block in GHA
     local_name="localhost:5000/${value}"
     docker tag "${value}" "${local_name}"
     docker push "${local_name}"
@@ -92,7 +89,3 @@ for key in "${!MULTIARCH_IMAGES[@]}"; do
     #docker manifest push "${latest_tag_alias}"
   fi
 done
-
-# stop the local registry
-rapids-echo-stderr "Stopping local registry"
-docker stop tmp-registry

--- a/tools/rapids-docker-multiarch-from-s3
+++ b/tools/rapids-docker-multiarch-from-s3
@@ -1,9 +1,21 @@
 #!/bin/bash
 # A utility script that downloads all docker images from S3
 # and assembles them into multiarch tags
+# Positional Arguments:
+#   1) latest tag to match
+#   2) latest tag alias to apply if tag matches latest tag 
 set -eo pipefail
+set -x
 source rapids-constants
 export RAPIDS_SCRIPT_NAME="rapids-docker-multiarch-from-s3"
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+  rapids-echo-stderr "Must specify input arguments: LATEST_TAG and LATEST_TAG_ALIAS"
+  exit 1
+fi
+
+latest_tag="$1"
+latest_tag_alias="$2"
 
 DOCKER_TMP_DIR="$(mktemp -d)"
 
@@ -22,7 +34,7 @@ DOCKER_TARBALLS=$(
     --bucket "${RAPIDS_DOWNLOADS_BUCKET}" \
     --prefix "${BUCKET_PREFIX}" \
     --page-size 100 \
-    --query "Contents[?starts_with(Key, '${DOCKER_STARTS_WITH}') && ends_with(Key, '${DOCKER_ENDS_WITH}')].Key" \
+    --query "Contents[?contains(Key, '${DOCKER_STARTS_WITH}') && ends_with(Key, '${DOCKER_ENDS_WITH}')].Key" \
     | jq -c
 )
 export DOCKER_TARBALLS
@@ -43,13 +55,15 @@ for OBJ in $(jq -nr 'env.DOCKER_TARBALLS | fromjson | .[]'); do
   loaded_image="${loaded_image/"Loaded image: "/}"
 
   # strip architecture hyphen
-  loaded_image_no_arch="${loaded_image_no_arch/"-x86_64"/}"
-  loaded_image_no_arch="${loaded_image_no_arch/"-aarch64"/}"
+  loaded_image="${loaded_image/"-x86_64"/}"
+  loaded_image="${loaded_image/"-aarch64"/}"
 
   # no-arch tag is the final multiarch tag
-  multiarch_tag="${loaded_image_no_arch}"
+  multiarch_tag="${loaded_image}"
 
   MULTIARCH_IMAGES[${multiarch_tag}]+="${loaded_image}"
 done
 
 echo "${MULTIARCH_IMAGES}"
+
+echo "Now checking ${latest_tag} ${latest_tag_alias}"

--- a/tools/rapids-docker-multiarch-from-s3
+++ b/tools/rapids-docker-multiarch-from-s3
@@ -82,13 +82,13 @@ for key in "${!MULTIARCH_IMAGES[@]}"; do
   done
 
   # shellcheck disable=SC2086
-  docker manifest create "${key}" ${manifest_args}
+  docker manifest create --insecure "${key}" ${manifest_args}
   #docker manifest push "${key}"
 
   # if this image matches the latest, give it the additional latest tag
   if [ "${key}" == "${latest_tag}" ]; then
     # shellcheck disable=SC2086
-    docker manifest create "${latest_tag_alias}" ${manifest_args}
+    docker manifest create --insecure "${latest_tag_alias}" ${manifest_args}
     #docker manifest push "${latest_tag_alias}"
   fi
 done

--- a/tools/rapids-docker-multiarch-from-s3
+++ b/tools/rapids-docker-multiarch-from-s3
@@ -54,9 +54,11 @@ for OBJ in $(jq -nr 'env.DOCKER_TARBALLS | fromjson | .[]'); do
   loaded_image=$(docker load < "${DOCKER_TMP_DIR}/${FILENAME}")
   loaded_image="${loaded_image/"Loaded image: "/}"
 
-  # strip -$(uname -m)
+  # strip -$(uname -m) or amd64 or arm64
   loaded_image_no_arch="${loaded_image/"-x86_64"/}"
   loaded_image_no_arch="${loaded_image_no_arch/"-aarch64"/}"
+  loaded_image_no_arch="${loaded_image_no_arch/"-amd64"/}"
+  loaded_image_no_arch="${loaded_image_no_arch/"-arm64"/}"
 
   # no-arch tag is the final multiarch tag
   multiarch_tag="${loaded_image_no_arch}"

--- a/tools/rapids-docker-multiarch-from-s3
+++ b/tools/rapids-docker-multiarch-from-s3
@@ -54,16 +54,20 @@ for OBJ in $(jq -nr 'env.DOCKER_TARBALLS | fromjson | .[]'); do
   loaded_image=$(docker load < "${DOCKER_TMP_DIR}/${FILENAME}")
   loaded_image="${loaded_image/"Loaded image: "/}"
 
-  # strip architecture hyphen
-  loaded_image="${loaded_image/"-x86_64"/}"
-  loaded_image="${loaded_image/"-aarch64"/}"
+  # strip -$(uname -m)
+  loaded_image_no_arch="${loaded_image/"-x86_64"/}"
+  loaded_image_no_arch="${loaded_image_no_arch/"-aarch64"/}"
 
   # no-arch tag is the final multiarch tag
-  multiarch_tag="${loaded_image}"
+  multiarch_tag="${loaded_image_no_arch}"
 
-  MULTIARCH_IMAGES[${multiarch_tag}]+="${loaded_image}"
+  # store per-arch image in the associative array by multiarch tag
+  MULTIARCH_IMAGES["${multiarch_tag}"]+=" ${loaded_image}"
 done
 
-echo "${MULTIARCH_IMAGES}"
+for key in "${!MULTIARCH_IMAGES[@]}"; do
+  values="${MULTIARCH_IMAGES[$key]}"
+  rapids-echo-stderr "Preparing multiarch manifest for: ${key} with per-arch images: ${values}"
+done
 
 echo "Now checking ${latest_tag} ${latest_tag_alias}"

--- a/tools/rapids-docker-multiarch-from-s3
+++ b/tools/rapids-docker-multiarch-from-s3
@@ -43,7 +43,7 @@ for OBJ in $(jq -nr 'env.DOCKER_TARBALLS | fromjson | .[]'); do
   S3_URI="${S3_PATH}${FILENAME}"
 
   rapids-echo-stderr "Downloading ${S3_URI} into ${DOCKER_TMP_DIR}"
-  aws s3 cp --only-show-errors "${S3_URI}" "${DOCKER_TMP_DIR}"/
+  aws s3 cp --only-show-errors "${S3_URI}" "${DOCKER_TMP_DIR}"/ 1>&2
 
   rapids-echo-stderr "Loading into docker"
   loaded_image=$(docker load < "${DOCKER_TMP_DIR}/${FILENAME}")
@@ -72,19 +72,19 @@ for key in "${!MULTIARCH_IMAGES[@]}"; do
   for value in ${values}; do
     # use the local registry set up by the `service` block in GHA
     local_name="localhost:5000/${value}"
-    docker tag "${value}" "${local_name}"
-    docker push "${local_name}"
+    docker tag "${value}" "${local_name}" 1>&2
+    docker push "${local_name}" 1>&2
     manifest_args+="--amend ${local_name} "
   done
 
   # shellcheck disable=SC2086
-  docker manifest create --insecure "${key}" ${manifest_args}
+  docker manifest create --insecure "${key}" ${manifest_args} 1>&2
   manifests_to_push+=("${key}")
 
   # if latest tags have been supplied this image matches the latest, give it the additional latest tag
   if [ -n "${latest_tag}" ] && [ -n "${latest_tag_alias}" ] && [ "${key}" == "${latest_tag}" ]; then
     # shellcheck disable=SC2086
-    docker manifest create --insecure "${latest_tag_alias}" ${manifest_args}
+    docker manifest create --insecure "${latest_tag_alias}" ${manifest_args} 1>&2
     manifests_to_push+=("${latest_tag_alias}")
   fi
 done

--- a/tools/rapids-docker-multiarch-from-s3
+++ b/tools/rapids-docker-multiarch-from-s3
@@ -82,7 +82,7 @@ for key in "${!MULTIARCH_IMAGES[@]}"; do
   # shellcheck disable=SC2086
   docker manifest create --insecure "${local_manifest}" ${manifest_args} 1>&2
   docker manifest push "${local_manifest}"
-  manifests_to_copy+=("${local_manifest}")
+  manifests_to_copy+=("${key}")
 
   # if latest tags have been supplied this image matches the latest, give it the additional latest tag
   if [ -n "${latest_tag}" ] && [ -n "${latest_tag_alias}" ] && [ "${key}" == "${latest_tag}" ]; then
@@ -91,7 +91,7 @@ for key in "${!MULTIARCH_IMAGES[@]}"; do
     # shellcheck disable=SC2086
     docker manifest create --insecure "${local_latest}" ${manifest_args} 1>&2
     docker manifest push "${local_latest}"
-    manifests_to_copy+=("${local_latest}")
+    manifests_to_copy+=("${latest_tag_alias}")
   fi
 done
 

--- a/tools/rapids-docker-multiarch-from-s3
+++ b/tools/rapids-docker-multiarch-from-s3
@@ -65,9 +65,34 @@ for OBJ in $(jq -nr 'env.DOCKER_TARBALLS | fromjson | .[]'); do
   MULTIARCH_IMAGES["${multiarch_tag}"]+=" ${loaded_image}"
 done
 
+# start a local registry
+rapids-echo-stderr "Starting local registry"
+docker run -d -p 5000:5000 --restart=always --name tmp-registry registry:2
+
 for key in "${!MULTIARCH_IMAGES[@]}"; do
   values="${MULTIARCH_IMAGES[$key]}"
   rapids-echo-stderr "Preparing multiarch manifest for: ${key} with per-arch images: ${values}"
+
+  manifest_args=""
+  for value in ${values}; do
+    local_name="localhost:5000/${value}"
+    docker tag "${value}" "${local_name}"
+    docker push "${local_name}"
+    manifest_args+="--amend ${local_name} "
+  done
+
+  # shellcheck disable=SC2086
+  docker manifest create "${key}" ${manifest_args}
+  #docker manifest push "${key}"
+
+  # if this image matches the latest, give it the additional latest tag
+  if [ "${key}" == "${latest_tag}" ]; then
+    # shellcheck disable=SC2086
+    docker manifest create "${latest_tag_alias}" ${manifest_args}
+    #docker manifest push "${latest_tag_alias}"
+  fi
 done
 
-echo "Now checking ${latest_tag} ${latest_tag_alias}"
+# stop the local registry
+rapids-echo-stderr "Stopping local registry"
+docker stop tmp-registry

--- a/tools/rapids-docker-multiarch-from-s3
+++ b/tools/rapids-docker-multiarch-from-s3
@@ -1,7 +1,7 @@
 #!/bin/bash
 # A utility script that downloads all docker images from S3
 # and assembles them into multiarch tags
-# Positional Arguments:
+# Optional Positional Arguments:
 #   1) latest tag to match
 #   2) latest tag alias to apply if tag matches latest tag 
 set -eo pipefail
@@ -9,13 +9,8 @@ set -x
 source rapids-constants
 export RAPIDS_SCRIPT_NAME="rapids-docker-multiarch-from-s3"
 
-if [ -z "$1" ] || [ -z "$2" ]; then
-  rapids-echo-stderr "Must specify input arguments: LATEST_TAG and LATEST_TAG_ALIAS"
-  exit 1
-fi
-
-latest_tag="$1"
-latest_tag_alias="$2"
+latest_tag="$1:-"
+latest_tag_alias="$2:-"
 
 DOCKER_TMP_DIR="$(mktemp -d)"
 
@@ -67,6 +62,8 @@ for OBJ in $(jq -nr 'env.DOCKER_TARBALLS | fromjson | .[]'); do
   MULTIARCH_IMAGES["${multiarch_tag}"]+=" ${loaded_image}"
 done
 
+manifests_to_push=()
+
 for key in "${!MULTIARCH_IMAGES[@]}"; do
   values="${MULTIARCH_IMAGES[$key]}"
   rapids-echo-stderr "Preparing multiarch manifest for: ${key} with per-arch images: ${values}"
@@ -82,12 +79,14 @@ for key in "${!MULTIARCH_IMAGES[@]}"; do
 
   # shellcheck disable=SC2086
   docker manifest create --insecure "${key}" ${manifest_args}
-  #docker manifest push "${key}"
+  manifests_to_push+=("${key}")
 
-  # if this image matches the latest, give it the additional latest tag
-  if [ "${key}" == "${latest_tag}" ]; then
+  # if latest tags have been supplied this image matches the latest, give it the additional latest tag
+  if [ -n "${latest_tag}" ] && [ -n "${latest_tag_alias}" ] && [ "${key}" == "${latest_tag}" ]; then
     # shellcheck disable=SC2086
     docker manifest create --insecure "${latest_tag_alias}" ${manifest_args}
-    #docker manifest push "${latest_tag_alias}"
+    manifests_to_push+=("${latest_tag_alias}")
   fi
 done
+
+echo -n "${manifests_to_push[@]}"

--- a/tools/rapids-docker-multiarch-from-s3
+++ b/tools/rapids-docker-multiarch-from-s3
@@ -81,7 +81,7 @@ for key in "${!MULTIARCH_IMAGES[@]}"; do
 
   # shellcheck disable=SC2086
   docker manifest create --insecure "${local_manifest}" ${manifest_args} 1>&2
-  docker manifest push "${local_manifest}"
+  docker manifest push "${local_manifest}" 1>&2
   manifests_to_copy+=("${key}")
 
   # if latest tags have been supplied this image matches the latest, give it the additional latest tag
@@ -90,7 +90,7 @@ for key in "${!MULTIARCH_IMAGES[@]}"; do
 
     # shellcheck disable=SC2086
     docker manifest create --insecure "${local_latest}" ${manifest_args} 1>&2
-    docker manifest push "${local_latest}"
+    docker manifest push "${local_latest}" 1>&2
     manifests_to_copy+=("${latest_tag_alias}")
   fi
 done

--- a/tools/rapids-download-docker-from-s3
+++ b/tools/rapids-download-docker-from-s3
@@ -4,7 +4,7 @@
 #   1) image tag
 set -eo pipefail
 source rapids-constants
-export RAPIDS_SCRIPT_NAME="rapids-download-docker-to-s3"
+export RAPIDS_SCRIPT_NAME="rapids-download-docker-from-s3"
 
 tmp_dir="$(mktemp -d)"
 
@@ -16,7 +16,7 @@ fi
 docker_image="$1"
 
 # replace "rapidsai/..." with "rapidsai_..." to use as file name
-docker_image_no_slash="$(echo ${docker_image} | sed 's#rapidsai/#rapidsai_#g')"
+docker_image_no_slash="$(echo ${docker_image} | sed 's#/#_#g')"
 docker_image_s3_name="docker_${docker_image_no_slash}.tar.gz"
 tmp_fname="${tmp_dir}/${docker_image_no_slash}.tar.gz"
 

--- a/tools/rapids-download-docker-from-s3
+++ b/tools/rapids-download-docker-from-s3
@@ -15,8 +15,8 @@ fi
 
 docker_image="$1"
 
-# replace "rapidsai/..." with "rapidsai_..." to use as file name
-docker_image_no_slash="$(echo ${docker_image} | sed 's#/#_#g')"
+# replace "/..." with "_..." to use as file name
+docker_image_no_slash="${docker_image//\//_}"
 docker_image_s3_name="docker_${docker_image_no_slash}.tar.gz"
 tmp_fname="${tmp_dir}/${docker_image_no_slash}.tar.gz"
 

--- a/tools/rapids-download-docker-from-s3
+++ b/tools/rapids-download-docker-from-s3
@@ -1,0 +1,28 @@
+#!/bin/bash
+# A utility script that downloads a docker image from S3
+# Positional Arguments:
+#   1) image tag
+set -eo pipefail
+source rapids-constants
+export RAPIDS_SCRIPT_NAME="rapids-download-docker-to-s3"
+
+tmp_dir="$(mktemp -d)"
+
+if [ -z "$1" ]; then
+  rapids-echo-stderr "Must specify input argument: IMAGE_TAG"
+  exit 1
+fi
+
+docker_image="$1"
+
+# replace "rapidsai/..." with "rapidsai_..." to use as file name
+docker_image_no_slash="$(echo ${docker_image} | sed 's#rapidsai/#rapidsai_#g')"
+docker_image_s3_name="docker_${docker_image_no_slash}.tar.gz"
+tmp_fname="${tmp_dir}/${docker_image_no_slash}.tar.gz"
+
+# download .tar.gz into tmpdir
+s3_dl_path="$(rapids-s3-path)${docker_image_s3_name}"
+aws s3 cp --only-show-errors "${s3_dl_path}" "${tmp_fname}"
+
+# load into docker
+docker load < "${tmp_fname}"

--- a/tools/rapids-upload-docker-to-s3
+++ b/tools/rapids-upload-docker-to-s3
@@ -14,8 +14,8 @@ fi
 
 docker_image="$1"
 
-# replace "rapidsai/..." with "rapidsai_..." to use as file name
-docker_image_no_slash="$(echo ${docker_image} | sed 's#rapidsai/#rapidsai_#g')"
+# replace "/..." with "_..." to use as file name
+docker_image_no_slash="$(echo ${docker_image} | sed 's#/#_#g')"
 docker_image_s3_name="docker_${docker_image_no_slash}.tar.gz"
 tmp_fname="${tmp_dir}/${docker_image_no_slash}.tar.gz"
 

--- a/tools/rapids-upload-docker-to-s3
+++ b/tools/rapids-upload-docker-to-s3
@@ -15,7 +15,7 @@ fi
 docker_image="$1"
 
 # replace "/..." with "_..." to use as file name
-docker_image_no_slash="$(echo ${docker_image} | sed 's#/#_#g')"
+docker_image_no_slash="${docker_image//\//_}"
 docker_image_s3_name="docker_${docker_image_no_slash}.tar.gz"
 tmp_fname="${tmp_dir}/${docker_image_no_slash}.tar.gz"
 

--- a/tools/rapids-upload-docker-to-s3
+++ b/tools/rapids-upload-docker-to-s3
@@ -1,0 +1,24 @@
+#!/bin/bash
+# A utility script that uploads a docker image tag to S3
+# Positional Arguments:
+#   1) image tag
+set -eo pipefail
+export RAPIDS_SCRIPT_NAME="rapids-upload-docker-to-s3"
+
+tmp_dir="$(mktemp -d)"
+
+if [ -z "$1" ]; then
+  rapids-echo-stderr "Must specify input argument: IMAGE_TAG"
+  exit 1
+fi
+
+docker_image="$1"
+
+# replace "rapidsai/..." with "rapidsai_..." to use as file name
+docker_image_no_slash="$(echo ${docker_image} | sed 's#rapidsai/#rapidsai_#g')"
+docker_image_s3_name="docker_${docker_image_no_slash}.tar.gz"
+tmp_fname="${tmp_dir}/${docker_image_no_slash}.tar.gz"
+
+docker save "${docker_image}" | gzip > "${tmp_fname}"
+
+rapids-upload-to-s3 "${docker_image_s3_name}" "${tmp_fname}"


### PR DESCRIPTION
This PR introduces 3 new gha-tools intended for building docker multiarch images from native hardware:
* `rapids-upload-docker-to-s3`, which takes a local docker tag and uploads it as a tarball to downloads.rapids.ai
* `rapids-download-docker-from-s3`, which downloads a docker tag from downloads.rapids.ai and loads it
* `rapids-docker-multiarch-from-s3`, which downloads all of the uploaded docker tarballs, loads them, pushes them to an ephemeral docker registry, assembles a multiarch manifest, and pushes that to the same ephemeral registry

Currently, building a multiarch image from two local separate architecture images is difficult/impossible: https://github.com/docker/cli/issues/3350 

In cibuildwheel-imgs, I came up with an approach as follows:

For the purposes of this written description, let's assume we have a multiarch image `foo`, for whom we want each of x86_64 and aarch64 to be built natively on a host of that same architecture

1. First, on native hosts (amd64 and arm64), build each image, appending the runner arch: `foo-x86_64`, `foo-aarch64`
2. Use `rapids-upload-docker-to-s3 foo-$arch` to upload `foo-$arch` tarballs to downloads.rapids.ai from each native builder instance
3. [**OPTIONAL**] On native hosts, use `rapids-download-docker-from-s3` to fetch the image, run security scans, unit tests, GPU tests, etc., as needed, before moving onto the final layer
4. In the final layer, the "multiarch assembler", do the following
    1. Set up an ephemeral remote docker registry during the GHA workflow run, using the `service:` key: https://github.com/rapidsai/cibuildwheel-imgs/blob/3943c3f7f22fe7e578dce334a24885fdd8e5e432/.github/workflows/docker-multiarch-native.yml#L109 
        1. This registry is an insecure local registry running as `localhost:5000`
    2. Use `rapids-docker-multiarch-from-s3`, which will do this:
        1. Download `foo-x86_64` from downloads.rapids.ai and `docker load` it
        2. Download `foo-aarch64` from downloads.rapids.ai and `docker load` it
        5. Prepend `localhost:5000/foo-x86_64` and push it to the local registry
        6. Prepend `localhost:5000/foo-aarch64` and push it to the local registry
        7. Now that these are available in a "remote" registry, we can multiarch assemble it
        8. Use `docker manifest create localhost:5000/foo --amend localhost:5000/foo-x86_64 --amend localhost:5000/foo-aarch64` and push it
    3. At this point, `localhost:5000/` contains `foo`, `foo-aarch64`, and `foo-x86_64`
    4. The final step is `skopeo copy localhost:5000/foo dockerhub/foo`
        1. We did all the remote pushing mess in an ephemeral registry, and copy only the final result to dockerhub

Note that the `rapids-download-docker-from-s3` can be used to download each per-arch image in an extra step, for example to do a security scan or unit tests.