### PR TITLE
Update `RAPIDS_DATE_STRING`

### DIFF
--- a/tools/rapids-env-update
+++ b/tools/rapids-env-update
@@ -18,5 +18,9 @@ if [ "${CI:-false}" = "false" ]; then
   export RAPIDS_BUILD_TYPE=${RAPIDS_BUILD_TYPE:-"pull-request"}
 fi
 
-VERSION_SUFFIX=$(git show --no-patch --date=format:'%y%m%d' --format='%cd')
-export VERSION_SUFFIX RAPIDS_DATE_STRING=$VERSION_SUFFIX
+RAPIDS_DATE_STRING="$(date +%y%m%d)"
+if [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
+  WORKFLOW_DATE=$(rapids-retry gh run view "${GITHUB_RUN_ID}" --json createdAt | jq -r '.createdAt')
+  RAPIDS_DATE_STRING=$(date -d "${WORKFLOW_DATE}" +%y%m%d)
+fi
+export RAPIDS_DATE_STRING

--- a/tools/rapids-logger
+++ b/tools/rapids-logger
@@ -20,4 +20,4 @@ function rapids-logger {
   echo -e "\033[32m└${bar}┘\033[0m\n"
 }
 
-rapids-logger "$@"
+rapids-logger "$@" >&2


### PR DESCRIPTION
This PR updates how `RAPIDS_DATE_STRING` is computed.

The variable's value is now computed from the workflow run date.

This will help ensure that RAPIDS packages are published on a nightly basis even if no changes to the source code have been made.