### PR TITLE
Add message about viewing docs locally to `rapids-upload-docs`

### DIFF
--- a/tools/rapids-upload-docs
+++ b/tools/rapids-upload-docs
@@ -1,4 +1,20 @@
 #!/bin/bash
+# This script uploads RAPIDS docs to S3.
+# The docs are expected to be in the following directory structure:
+# $RAPIDS_DOCS_DIR
+# ├── cudf
+# │   ├── html
+# │   │   └── <html files>
+# │   └── txt
+# │       └── <txt files>
+# └── dask-cudf
+#     ├── html
+#     │   └── <html files>
+#     └── txt
+#         └── <txt files>
+# Required Environment Variables:
+#  - RAPIDS_DOCS_DIR - a path to a directory containing the docs to upload
+#  - RAPIDS_VERSION_NUMBER - the version number of the docs being uploaded
 set -euo pipefail
 
 checks() {

--- a/tools/rapids-upload-docs
+++ b/tools/rapids-upload-docs
@@ -9,6 +9,9 @@ checks() {
 
   if [[ "${GITHUB_ACTIONS:-false}" != "true" ]]; then
     echo "Uploading docs from local builds is not supported."
+    echo "The docs are in ${RAPIDS_DOCS_DIR}."
+    echo "They can be viewed in a web browser by running:"
+    echo "python -m http.server --directory ${RAPIDS_DOCS_DIR}"
     exit 0
   fi
 


### PR DESCRIPTION
As noted in https://github.com/rapidsai/rmm/pull/1288, the value of `RAPIDS_DOCS_DIR` is random and generated by `mktemp -d`.

Therefore, it will be useful to print out this directory for users who are doing local builds according to the repro instructions here: https://docs.rapids.ai/resources/reproducing-ci/.

Additionally, a `python -m http.server` command is printed so that users can view the built docs in their browser.