### PR TITLE
Fix prompts for running a nightly build/test locally

### DIFF
--- a/tools/rapids-download-conda-from-s3
+++ b/tools/rapids-download-conda-from-s3
@@ -51,8 +51,12 @@ if [ "${CI:-false}" = "false" ]; then
   if [ -z "${RAPIDS_REF_NAME:-}" ]; then
     {
       echo ""
-      read -r -p "Enter pull-request number (e.g. 1546): " PR_NUMBER
-      RAPIDS_REF_NAME=pull-request/${PR_NUMBER}
+      if [ "${RAPIDS_BUILD_TYPE}" = "pull-request" ]; then
+        read -r -p "Enter pull-request number (e.g. 1546): " PR_NUMBER
+        RAPIDS_REF_NAME=pull-request/${PR_NUMBER}
+      else
+        read -r -p "Enter branch name (e.g. branch-23.08): " RAPIDS_REF_NAME
+      fi
       export RAPIDS_REF_NAME
       echo ""
       echo "Suppress this prompt in the future by setting the 'RAPIDS_REF_NAME' environment variable:"
@@ -74,6 +78,18 @@ if [ "${CI:-false}" = "false" ]; then
       fi
       echo ""
       export RAPIDS_SHA
+    } >&2
+  fi
+
+  if [ "${RAPIDS_BUILD_TYPE}" = "nightly" ] && [ -z "${RAPIDS_NIGHTLY_DATE:-}" ]; then
+    {
+      echo ""
+      read -r -p "Enter nightly date (e.g. 2023-06-20): " RAPIDS_NIGHTLY_DATE
+      export RAPIDS_NIGHTLY_DATE
+      echo ""
+      echo "Suppress this prompt in the future by setting the 'RAPIDS_NIGHTLY_DATE' environment variable:"
+      echo "export RAPIDS_NIGHTLY_DATE=${RAPIDS_NIGHTLY_DATE}"
+      echo ""
     } >&2
   fi
 fi


### PR DESCRIPTION
RAPIDS CI supports running CI builds locally using the instructions here: https://docs.rapids.ai/resources/reproducing-ci/
When a build step requires downloading from S3, the tools script will prompt for the needed environment variable settings.
```
export RAPIDS_BUILD_TYPE=pull-request # or "branch" or "nightly"
export RAPIDS_REPOSITORY=rapidsai/cugraph
export RAPIDS_REF_NAME=pull-request/3258 # or "branch-YY.MM" for "branch"/"nightly" builds
```

The steps for reproducing a `nightly` test were not working and produced the following result.

```
[rapids-download-conda-from-s3] Local run detected.
[rapids-download-conda-from-s3] NVIDIA VPN connectivity is required to download workflow artifacts.

Enter workflow type (one of: pull-request|branch|nightly): nightly

Suppress this prompt in the future by setting the 'RAPIDS_BUILD_TYPE' environment variable:
export RAPIDS_BUILD_TYPE=nightly


Enter org/repository name (e.g. rapidsai/cudf): rapidsai/cudf

Suppress this prompt in the future by setting the 'RAPIDS_REPOSITORY' environment variable:
export RAPIDS_REPOSITORY=rapidsai/cudf


Enter pull-request number (e.g. 1546): branch-23.08

Suppress this prompt in the future by setting the 'RAPIDS_REF_NAME' environment variable:
export RAPIDS_REF_NAME=pull-request/branch-23.08


Using HEAD commit for artifact commit hash. Overwrite this by setting the 'RAPIDS_SHA' environment variable:
export RAPIDS_SHA=1854ac86d08e545376704959436ec370bdd8117a

/usr/local/bin/rapids-s3-path: line 40: RAPIDS_NIGHTLY_DATE: unbound variable

```
The nightly build requires the `RAPIDS_NIGHTLY_DATE` date in `YYYY-MM-DD` format and the `RAPIDS_REF_NAME` is expected to be the branch name.

This PR updates the prompt logic to allow running a nightly build locally.