### PR TITLE
Make rapids-twine look like rapids-twine-new

### DIFF
--- a/tools/rapids-twine
+++ b/tools/rapids-twine
@@ -47,7 +47,7 @@ done
 # then run twine on all wheels
 export RAPIDS_RETRY_SLEEP=180
 # shellcheck disable=SC2086
-rapids-retry twine \
+rapids-retry python -m twine \
   upload \
   --disable-progress-bar \
   --non-interactive \


### PR DESCRIPTION
We know the `-new` version also works, so to minimize disruptions with existing workflows it'll be easiest to just modify the original script then eventually remove the `-new` version once nothing is using the legacy workflows that call it.