### PR TITLE
Fix `rapids-date-string`

### DIFF
--- a/tools/rapids-date-string
+++ b/tools/rapids-date-string
@@ -1,9 +1,25 @@
 #!/bin/bash
 # A utility script produces a date string
 
-RAPIDS_DATE_STRING="$(date +%y%m%d)"
+# TODO: remove default value after calling scripts are updated
+FORMAT_ARG="${1:-second}"
+
+case "${FORMAT_ARG}" in
+  day)
+    FORMAT="%y%m%d"
+    ;;
+  second)
+    FORMAT="%s"
+    ;;
+  *)
+    rapids-echo-stderr "Invalid format argument: ${FORMAT_ARG}"
+    exit 1
+    ;;
+esac
+
+RAPIDS_DATE_STRING="$(date +${FORMAT})"
 if [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
   WORKFLOW_DATE=$(rapids-retry gh run view "${GITHUB_RUN_ID}" --json createdAt | jq -r '.createdAt')
-  RAPIDS_DATE_STRING=$(date -d "${WORKFLOW_DATE}" +%y%m%d)
+  RAPIDS_DATE_STRING=$(date -d "${WORKFLOW_DATE}" +${FORMAT})
 fi
 export RAPIDS_DATE_STRING

--- a/tools/rapids-env-update
+++ b/tools/rapids-env-update
@@ -8,4 +8,4 @@ rapids-configure-conda-channels
 
 source rapids-configure-sccache
 
-source rapids-date-string
+source rapids-date-string day


### PR DESCRIPTION
As it turns out, using the `YYMMDD` format in `rapids-date-string` for wheels broke some things.

This PR adjusts `rapids-date-string` to generate both `YYMMDD` strings and "seconds since epoch" strings for wheels.

Since the new wheel scripts all call `rapida-date-string` without any arguments, the default argument is set to "second".

The default argument should be removed once `rapids-env-update` is deprecated and the individual repositories have been updated to call `rapids-date-string` in this new format.

`rapids-env-update` has also been updated to pass the `day` argument since all conda workflows currently get their `RAPIDS_DATE_STRING` value through that script.

To avoid having to pass arguments from the calling scripts in the future, we could create two new `gha-tools` scripts (e.g. `rapids-wheel-date-string` and `rapids-conda-date-string`) that call a "private" script (`_rapids-date-string`) with the appropriate arguments.