### PR TITLE
Trigger CI img rebuilds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,3 +35,14 @@ jobs:
         with:
           files: ${{ env.RELEASE_FILE_NAME }}
           tag_name: ${{ env.NEXT_PATCH_VERSION }}
+  trigger-pipeline:
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Trigger CI Images
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+        run: |
+          gh workflow run push.yml \
+          --repo github.com/rapidsai/ci-imgs \
+          --ref main


### PR DESCRIPTION
Configures the release workflow to trigger `build-and-publish-images` workflow of `ci-imgs` due to being an upstream dependency.