### PR TITLE
Remove path constraint from PR workflow

### DIFF
--- a/.github/workflows/prs.yaml
+++ b/.github/workflows/prs.yaml
@@ -2,8 +2,6 @@ name: prs
 
 on:
   pull_request:
-    paths:
-      - "tools/*"
 
 defaults:
   run:


### PR DESCRIPTION
The constraint prevented checks from being run on PRs