### PR TITLE
Halt docs uploads for branch/nightlies

### DIFF
--- a/tools/rapids-upload-docs
+++ b/tools/rapids-upload-docs
@@ -24,6 +24,11 @@ checks() {
     exit 1
   fi
 
+  if [[ "${RAPIDS_BUILD_TYPE}" != "pull-request" ]]; then
+    echo "DOCS UPLOADS FOR BRANCH/NIGHTLIES HAVE BEEN TEMPORARILY HALTED"
+    exit 0
+  fi
+
   if [[ "${GITHUB_ACTIONS:-false}" != "true" ]]; then
     echo "Uploading docs from local builds is not supported."
     echo "The docs are in ${RAPIDS_DOCS_DIR}."


### PR DESCRIPTION
Work is ongoing to re-arrange the directory structure for the branch/nightly docs stored on s3 so this PR (temporarily) halts uploads to s3 in order to facilitate that work.

Uploads will be re-enabled once the work is complete.

NOTE: Uploads from pull-requests are still allowed because the associated s3 bucket is a different bucket from the one currently being re-structured.