### PR TITLE
Include additional docs upload format "xml_tar"

### DIFF
--- a/tools/rapids-upload-docs
+++ b/tools/rapids-upload-docs
@@ -77,7 +77,7 @@ copy_docs_to_s3() {
       fi
 
       if [[ "${FORMAT}" == "xml_tar" ]]; then
-        NUM_FILES=$(find "$PROJECT_FORMAT_DIR" -maxdepth 1 -type f | wc -l)
+        NUM_FILES=$(find "$PROJECT_FORMAT_DIR" -type f | wc -l)
         if [[ ! -f "${PROJECT_FORMAT_DIR}/xml.tar.gz" || $NUM_FILES -ne 1 ]]; then
             echo "Error: The xml_tar directory should contain a single file named xml.tar.gz."
             exit 1
@@ -86,15 +86,14 @@ copy_docs_to_s3() {
 
       rapids-logger "Uploading ${RAPIDS_VERSION_NUMBER} ${PROJECT} ${FORMAT} docs to S3."
 
+      ACL_OPTION="private"
       if [[ "$FORMAT" == "xml_tar" ]]; then
-          ACL_OPTION="--acl public-read"
-      else
-          ACL_OPTION=""
+          ACL_OPTION="public-read"
       fi
       aws s3 sync \
         --no-progress \
         --delete \
-        "${ACL_OPTION}" \
+        --acl "${ACL_OPTION}" \
         "${PROJECT_FORMAT_DIR}" \
         "$(get_s3_dest "${PROJECT}" "${FORMAT}")"
       echo ""

--- a/tools/rapids-upload-docs
+++ b/tools/rapids-upload-docs
@@ -71,16 +71,30 @@ copy_docs_to_s3() {
     for PROJECT_FORMAT_DIR in "${PROJECT_DIR}"/*; do
       FORMAT=$(basename "${PROJECT_FORMAT_DIR}")
 
-      if [[ ! "${FORMAT}" =~ ^(html|txt)$ ]]; then
-        echo "ERROR: FORMAT must be either 'html' or 'txt'."
+      if [[ ! "${FORMAT}" =~ ^(html|txt|xml_tar)$ ]]; then
+        echo "ERROR: FORMAT must be either 'html' or 'txt' or 'xml_tar'."
         exit 1
+      fi
+
+      if [[ "${FORMAT}" == "xml_tar" ]]; then
+        NUM_FILES=$(find "$PROJECT_FORMAT_DIR" -maxdepth 1 -type f | wc -l)
+        if [[ ! -f "${PROJECT_FORMAT_DIR}/xml.tar.gz" || $NUM_FILES -ne 1 ]]; then
+            echo "Error: The xml_tar directory should contain a single file named xml.tar.gz."
+            exit 1
+        fi
       fi
 
       rapids-logger "Uploading ${RAPIDS_VERSION_NUMBER} ${PROJECT} ${FORMAT} docs to S3."
 
+      if [[ "$FORMAT" == "xml_tar" ]]; then
+          ACL_OPTION="--acl public-read"
+      else
+          ACL_OPTION=""
+      fi
       aws s3 sync \
         --no-progress \
         --delete \
+        "${ACL_OPTION}" \
         "${PROJECT_FORMAT_DIR}" \
         "$(get_s3_dest "${PROJECT}" "${FORMAT}")"
       echo ""


### PR DESCRIPTION
In the ongoing work to consolidate the rendered docs for all graph repositories (`cugraph`, `cugraph-ops`, `wholegraph`) into one place, `wholegraph` and `cugraph-ops` c++ docs will be uploaded as xml tarballs, which will then be consumed during the docs build process for `cugraph` and ultimately rendered under `cugraph`.

This PR enables the tarball upload.