### PR TITLE
Switch `gh` command to use `git`

### DIFF
--- a/tools/rapids-get-pr-conda-artifact
+++ b/tools/rapids-get-pr-conda-artifact
@@ -30,7 +30,7 @@ esac
 
 commit="${4:-}"
 if [[ -z "${commit}" ]]; then
-    commit=$(gh api "/repos/rapidsai/${repo}/pulls/${pr}" -q '.head.sha[:7]')
+    commit=$(git ls-remote https://github.com/rapidsai/"${repo}".git refs/heads/pull-request/"${pr}" | cut -c1-7)
 fi
 
 rapids-get-artifact "ci/${repo}/pull-request/${pr}/${commit}/${artifact_name}"


### PR DESCRIPTION
This PR switches a command in `rapids-get-pr-conda-artifact` to use `git` instead of `gh`.

`gh` requires a token, which is annoying to set up.