### PR TITLE
update versions of third-party actions

### DIFF
--- a/.github/workflows/prs.yaml
+++ b/.github/workflows/prs.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:
@@ -42,7 +42,7 @@ jobs:
               fi
             done
           done
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Run pytest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Package tools


### PR DESCRIPTION
Proposes updating to the latest versions of third-party actions used here:

* `actions/checkout` = `v2` (Mar. 24, 2023) / `v3` (Aug. 24, 2023) to `v4` (Oct. 17, 2023)
    - release notes: https://github.com/actions/checkout/releases
* `actions/setup-python` = `v4` (Sep. 7, 2023) to `v5` (Dec. 6, 2023)
    - release notes: https://github.com/actions/setup-python/releases

I'm hoping both should be non-controversial...it looks to me like this project has only minimal exposure to those actions' public APIs, and that workflows here run on GitHub-hosted `ubuntu-latest`.