### PR TITLE
Add support for pure Python wheels.

### DIFF
--- a/tools/rapids-package-name
+++ b/tools/rapids-package-name
@@ -31,11 +31,11 @@ case "${pkg_type}" in
     ;;
   wheel_python)
     append_wheelname=1
-    append_pyver=1
-    append_arch=1
-    ;;
-  wheel_python_pure)
-    append_wheelname=1
+    # Pure wheels do not need a pyver or arch
+    if [[ ! -v RAPIDS_PY_WHEEL_PURE ]] || [[ "${RAPIDS_PY_WHEEL_PURE}" != "1" ]]; then
+      append_pyver=1
+      append_arch=1
+    fi
     ;;
   *)
     rapids-echo-stderr "Nonstandard package type '${pkg_type}'"

--- a/tools/rapids-package-name
+++ b/tools/rapids-package-name
@@ -57,7 +57,7 @@ fi
 
 # for python package types (except pure wheels), add pyver
 if (( append_pyver == 1 )); then
-  pkg_name+="_${RAPIDS_PY_VERSION//./}"
+  pkg_name+="_py${RAPIDS_PY_VERSION//./}"
 fi
 
 # for cpp and python package types (except pure wheels), append the arch

--- a/tools/rapids-package-name
+++ b/tools/rapids-package-name
@@ -15,19 +15,26 @@ fi
 pkg_type="$1"
 
 append_cuda=0
-append_pyver=0
 append_wheelname=0
+append_pyver=0
+append_arch=0
 
 case "${pkg_type}" in
   conda_cpp)
     append_cuda=1
+    append_arch=1
     ;;
   conda_python)
     append_cuda=1
     append_pyver=1
+    append_arch=1
     ;;
   wheel_python)
+    append_wheelname=1
     append_pyver=1
+    append_arch=1
+    ;;
+  wheel_python_pure)
     append_wheelname=1
     ;;
   *)
@@ -48,21 +55,23 @@ if (( append_wheelname )) && [[ -v RAPIDS_PY_WHEEL_NAME ]] && [[ "${RAPIDS_PY_WH
   pkg_name+="_${RAPIDS_PY_WHEEL_NAME}"
 fi
 
-# for python package types, add pyver
+# for python package types (except pure wheels), add pyver
 if (( append_pyver == 1 )); then
   pkg_name+="_${RAPIDS_PY_VERSION//./}"
 fi
 
-# for cpp and python package types, always append arch
-if [[ -v RAPIDS_ARCH ]] && [[ "${RAPIDS_ARCH}" != "" ]]; then
-  # use arch override if specified
-  pkg_name+="_${RAPIDS_ARCH}"
-else
-  # otherwise use architecture of the host that's running the upload command
-  pkg_name+="_$(arch)"
+# for cpp and python package types (except pure wheels), append the arch
+if (( append_arch == 1)); then
+  if [[ -v RAPIDS_ARCH ]] && [[ "${RAPIDS_ARCH}" != "" ]]; then
+    # use arch override if specified
+    pkg_name+="_${RAPIDS_ARCH}"
+  else
+    # otherwise use architecture of the host that's running the upload command
+    pkg_name+="_$(arch)"
+  fi
 fi
 
-# for cpp and python package types, its a tarball, append .tar.gz and prepend project name
+# for cpp and python package types, it's a tarball, append .tar.gz and prepend project name
 pkg_name="${repo_name}_${pkg_name}.tar.gz"
 
 echo -n "${pkg_name}"


### PR DESCRIPTION
This improves the handling of pure Python wheels in `rapids-package-name`. When dealing with pure Python packages, we don't want the Python version or CPU arch to be a part of the package's identifiers.

After this is merged, we can adopt this change across RAPIDS repos for pure wheels like dask-cudf, cuxfilter, etc. and then revert https://github.com/rapidsai/shared-workflows/pull/188.

List of packages to check:
- [ ] dask-cudf https://github.com/rapidsai/cudf/pull/15223
- [ ] cuxfilter
- [ ] nx-cugraph
- [ ] cugraph-pyg
- [ ] cugraph-dgl
- [ ] cugraph-equivariant
- [ ] rapids-dask-dependency (No -cu suffix)