### PR TITLE
Add rapids-version and rapids-version-major-minor

### DIFF
--- a/tests/test_rapids-version.py
+++ b/tests/test_rapids-version.py
@@ -1,0 +1,33 @@
+from os import path
+import pytest
+import subprocess
+import tempfile
+
+TOOLS_DIR = path.join(path.dirname(path.realpath(__file__)), "..", "tools")
+
+
+def run_rapids_version(tool_name, cwd, exit_code, output):
+    process = subprocess.Popen([path.join(TOOLS_DIR, tool_name)], cwd=cwd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process.wait()
+    assert process.returncode == exit_code
+    assert process.stdout.read() == output
+    assert process.stderr.read() == ""
+
+@pytest.mark.parametrize(
+    "version_contents, exit_code, version, version_major_minor",
+    [
+        ("24.00.00\n", 0, "24.00.00\n", "24.00\n"),
+        ("24.02.00a1\n", 0, "24.02.00\n", "24.02\n"),
+        ("invalid\n", 1, "", ""),
+        ("", 1, "", ""),
+        (None, 1, "", ""),
+    ]
+)
+def test_rapids_version(version_contents, exit_code, version, version_major_minor):
+    with tempfile.TemporaryDirectory() as d:
+        if version_contents is not None:
+            with open(path.join(d, "VERSION"), "w") as f:
+                f.write(version_contents)
+
+        run_rapids_version("rapids-version", d, exit_code, version)
+        run_rapids_version("rapids-version-major-minor", d, exit_code, version_major_minor)

--- a/tools/rapids-version
+++ b/tools/rapids-version
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Prints the full RAPIDS version based on the VERSION file. Its output is meant to be stored in a variable.
+# Assumed to be run from the repository root.
+# Note that this strips off anything after the patch version (Python dev suffixes, etc.)
+# See also: rapids-version-major-minor
+#
+# $ rapids-version
+# 24.00.00
+set -euo pipefail
+
+readonly regex="^([0-9]{2})\.([0-9]{2})\.([0-9]{2}).*$"
+
+[[ -f VERSION ]]
+grep -E -q "$regex" VERSION
+sed -E -e "s/$regex/\1.\2.\3/" VERSION

--- a/tools/rapids-version-major-minor
+++ b/tools/rapids-version-major-minor
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Prints the RAPIDS version major/minor based on the VERSION file. Its output is meant to be stored in a variable.
+# Assumed to be run from the repository root.
+# See also: rapids-version
+#
+# $ rapids-version-major-minor
+# 24.00
+set -euo pipefail
+
+readonly regex="^([0-9]{2})\.([0-9]{2})\.([0-9]{2}).*$"
+
+[[ -f VERSION ]]
+grep -E -q "$regex" VERSION
+sed -E -e "s/$regex/\1.\2/" VERSION


### PR DESCRIPTION
These tools will allow shell scripts to easily read and parse the VERSION file in a uniform manner.

Issue: https://github.com/rapidsai/build-planning/issues/15