### PR TITLE
Retry on "Connection broken:" errors

### DIFF
--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -90,7 +90,7 @@ function runConda {
             retryingMsg="Retrying after cleaning tarball cache, found 'CondaMultiError:' in output..."
             needToRetry=1
             needToClean=1
-        elif grep -q "Connection broken:": "${outfile}"; then
+        elif grep -q "Connection broken:" "${outfile}"; then
             retryingMsg="Retrying, found 'Connection broken:' in output..."
             needToRetry=1
         elif grep -q ConnectionError: "${outfile}"; then

--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -77,27 +77,30 @@ function runConda {
         # Show exit code
         rapids-echo-stderr "conda returned exit code: ${exitcode}"
 
-        if grep -q CondaHTTPError: "${outfile}"; then
-            retryingMsg="Retrying, found 'CondaHTTPError:' in output..."
-            needToRetry=1
-        elif grep -q ChecksumMismatchError: "${outfile}"; then
+        if grep -q ChecksumMismatchError: "${outfile}"; then
             retryingMsg="Retrying, found 'ChecksumMismatchError:' in output..."
-            needToRetry=1
-        elif grep -q JSONDecodeError: "${outfile}"; then
-            retryingMsg="Retrying, found 'JSONDecodeError:' in output..."
             needToRetry=1
         elif grep -q ChunkedEncodingError: "${outfile}"; then
             retryingMsg="Retrying, found 'ChunkedEncodingError:' in output..."
+            needToRetry=1
+        elif grep -q CondaHTTPError: "${outfile}"; then
+            retryingMsg="Retrying, found 'CondaHTTPError:' in output..."
             needToRetry=1
         elif grep -q CondaMultiError: "${outfile}"; then
             retryingMsg="Retrying after cleaning tarball cache, found 'CondaMultiError:' in output..."
             needToRetry=1
             needToClean=1
-        elif grep -q EOFError: "${outfile}"; then
-            retryingMsg="Retrying, found 'EOFError:' in output..."
+        elif grep -q "Connection broken:": "${outfile}"; then
+            retryingMsg="Retrying, found 'Connection broken:' in output..."
             needToRetry=1
         elif grep -q ConnectionError: "${outfile}"; then
             retryingMsg="Retrying, found 'ConnectionError:' in output..."
+            needToRetry=1
+        elif grep -q EOFError: "${outfile}"; then
+            retryingMsg="Retrying, found 'EOFError:' in output..."
+            needToRetry=1
+        elif grep -q JSONDecodeError: "${outfile}"; then
+            retryingMsg="Retrying, found 'JSONDecodeError:' in output..."
             needToRetry=1
         elif grep -q "Multi-download failed" "${outfile}"; then
             retryingMsg="Retrying, found 'Multi-download failed' in output..."
@@ -115,6 +118,7 @@ function runConda {
 'ChunkedEncodingError:', \
 'CondaHTTPError:', \
 'CondaMultiError:', \
+'Connection broken:', \
 'ConnectionError:', \
 'EOFError:', \
 'JSONDecodeError:', \


### PR DESCRIPTION
Closes #98.

This PR adds a `rapids-conda-retry` mode for errors that include the string "Connection broken:".

This includes errors like the following:

```
("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
```

and

```
('Connection broken: IncompleteRead(584079781 bytes read, 131525879 more expected)', IncompleteRead(584079781 bytes read, 131525879 more expected))
('Connection broken: IncompleteRead(584079781 bytes read, 131525879 more expected)', IncompleteRead(584079781 bytes read, 131525879 more expected))
```

Also, I alphabetized the error modes to make it easier to read.