### PR TITLE
add rapids-get-pr-wheel-artifact for quickly downloading cpp wheels

### DIFF
--- a/tools/rapids-download-wheels-from-s3
+++ b/tools/rapids-download-wheels-from-s3
@@ -6,6 +6,15 @@ set -eo pipefail
 
 source rapids-prompt-local-repo-config
 
-pkg_name="$(rapids-package-name wheel_python)"
+pkg_type="$1"
+if [ "${pkg_type}" != "cpp" ] && [ "${pkg_type}" != "python" ]; then
+    rapids-echo-error "Wheel cpp packages are now supported."
+    rapids-echo-error "You must specify package type as the first argument to rapids-upload-wheels-to-s3"
+fi
+
+# remove pkg_type from args because we handle it in this script
+shift;
+
+pkg_name="$(rapids-package-name wheel_${pkg_type})"
 
 rapids-download-from-s3 "${pkg_name}" "$@"

--- a/tools/rapids-download-wheels-from-s3
+++ b/tools/rapids-download-wheels-from-s3
@@ -6,15 +6,14 @@ set -eo pipefail
 
 source rapids-prompt-local-repo-config
 
+# For legacy reasons, allow this script to be run without the pkg_type being the first arg
+pkg_name="$(rapids-package-name "wheel_python")"
+
 pkg_type="$1"
-if [ "${pkg_type}" != "cpp" ] && [ "${pkg_type}" != "python" ]; then
-    rapids-echo-error "Wheel cpp packages are now supported."
-    rapids-echo-error "You must specify package type as the first argument to rapids-upload-wheels-to-s3"
+if [ "${pkg_type}" = "cpp" ] || [ "${pkg_type}" = "python" ]; then
+    # remove pkg_type from args because we handle it in this script
+    shift;
+    pkg_name="$(rapids-package-name "wheel_${pkg_type}")"
 fi
-
-# remove pkg_type from args because we handle it in this script
-shift;
-
-pkg_name="$(rapids-package-name "wheel_${pkg_type}")"
 
 rapids-download-from-s3 "${pkg_name}" "$@"

--- a/tools/rapids-download-wheels-from-s3
+++ b/tools/rapids-download-wheels-from-s3
@@ -15,6 +15,6 @@ fi
 # remove pkg_type from args because we handle it in this script
 shift;
 
-pkg_name="$(rapids-package-name wheel_${pkg_type})"
+pkg_name="$(rapids-package-name "wheel_${pkg_type}")"
 
 rapids-download-from-s3 "${pkg_name}" "$@"

--- a/tools/rapids-get-pr-wheel-artifact
+++ b/tools/rapids-get-pr-wheel-artifact
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Echo path to an artifact for a specific PR. Finds and uses the latest commit on the PR.
+#
+# Positional Arguments:
+#   1) repo name
+#   2) PR number
+#   3) "cpp" or "python", to get the artifact for the C++ or Python build, respectively
+#   4) [optional] commit hash, to get the artifact for a specific commit
+#
+# Example Usage:
+#   rapids-get-pr-conda-artifact rmm 1095 cpp
+set -euo pipefail
+
+repo="$1"
+pr="$2"
+
+pkg_type="$3"
+case "${pkg_type}" in
+  cpp)
+    artifact_name=$(RAPIDS_REPOSITORY=$repo rapids-package-name wheel_cpp)
+    ;;
+  python)
+    artifact_name=$(RAPIDS_REPOSITORY=$repo rapids-package-name wheel_python)
+    ;;
+  *)
+    echo "Error: 3rd argument must be 'cpp' or 'python'"
+    exit 1
+    ;;
+esac
+
+commit="${4:-}"
+if [[ -z "${commit}" ]]; then
+    commit=$(git ls-remote https://github.com/rapidsai/"${repo}".git refs/heads/pull-request/"${pr}" | cut -c1-7)
+fi
+
+rapids-get-artifact "ci/${repo}/pull-request/${pr}/${commit}/${artifact_name}"

--- a/tools/rapids-package-name
+++ b/tools/rapids-package-name
@@ -31,7 +31,6 @@ case "${pkg_type}" in
     ;;
   wheel_cpp)
     append_wheelname=1
-    append_cuda=1
     append_arch=1
     ;;
   wheel_python)

--- a/tools/rapids-package-name
+++ b/tools/rapids-package-name
@@ -29,6 +29,11 @@ case "${pkg_type}" in
     append_pyver=1
     append_arch=1
     ;;
+  wheel_cpp)
+    append_wheelname=1
+    append_cuda=1
+    append_arch=1
+    ;;
   wheel_python)
     append_wheelname=1
     # Pure wheels do not need a pyver or arch

--- a/tools/rapids-package-name
+++ b/tools/rapids-package-name
@@ -17,6 +17,7 @@ pkg_type="$1"
 append_cuda=0
 append_wheelname=0
 append_pyver=0
+append_generic_pyver=0
 append_arch=0
 
 case "${pkg_type}" in
@@ -33,6 +34,7 @@ case "${pkg_type}" in
     append_wheelname=1
     append_cuda=1
     append_arch=1
+    append_generic_pyver=1
     ;;
   wheel_python)
     append_wheelname=1
@@ -63,6 +65,11 @@ fi
 # for python package types (except pure wheels), add pyver
 if (( append_pyver == 1 )); then
   pkg_name+="_py${RAPIDS_PY_VERSION//./}"
+fi
+
+# for wheels that bundle shared libraries, add generic pyver
+if (( append_generic_pyver == 1 )); then
+  pkg_name+="_py3"
 fi
 
 # for cpp and python package types (except pure wheels), append the arch

--- a/tools/rapids-package-name
+++ b/tools/rapids-package-name
@@ -17,7 +17,6 @@ pkg_type="$1"
 append_cuda=0
 append_wheelname=0
 append_pyver=0
-append_generic_pyver=0
 append_arch=0
 
 case "${pkg_type}" in
@@ -34,7 +33,6 @@ case "${pkg_type}" in
     append_wheelname=1
     append_cuda=1
     append_arch=1
-    append_generic_pyver=1
     ;;
   wheel_python)
     append_wheelname=1
@@ -65,11 +63,6 @@ fi
 # for python package types (except pure wheels), add pyver
 if (( append_pyver == 1 )); then
   pkg_name+="_py${RAPIDS_PY_VERSION//./}"
-fi
-
-# for wheels that bundle shared libraries, add generic pyver
-if (( append_generic_pyver == 1 )); then
-  pkg_name+="_py3"
 fi
 
 # for cpp and python package types (except pure wheels), append the arch

--- a/tools/rapids-upload-wheels-to-s3
+++ b/tools/rapids-upload-wheels-to-s3
@@ -19,6 +19,6 @@ if [ "${CI:-false}" = "false" ]; then
   exit 0
 fi
 
-pkg_name="$(rapids-package-name wheel_${pkg_type})"
+pkg_name="$(rapids-package-name "wheel_${pkg_type}")"
 
 rapids-upload-to-s3 "${pkg_name}" "$@"

--- a/tools/rapids-upload-wheels-to-s3
+++ b/tools/rapids-upload-wheels-to-s3
@@ -4,21 +4,20 @@
 #   1) wheel path to tar up
 set -e
 
-pkg_type="$1"
-if [ "${pkg_type}" != "cpp" ] && [ "${pkg_type}" != "python" ]; then
-    rapids-echo-error "Wheel cpp packages are now supported."
-    rapids-echo-error "You must specify package type as the first argument to rapids-upload-wheels-to-s3"
-fi
+# For legacy reasons, allow this script to be run without the pkg_type being the first arg
+pkg_name="$(rapids-package-name "wheel_python")"
 
-# remove pkg_type from args because we handle it in this script
-shift;
+pkg_type="$1"
+if [ "${pkg_type}" = "cpp" ] || [ "${pkg_type}" = "python" ]; then
+    # remove pkg_type from args because we handle it in this script
+    shift;
+    pkg_name="$(rapids-package-name "wheel_${pkg_type}")"
+fi
 
 if [ "${CI:-false}" = "false" ]; then
   rapids-echo-stderr "Packages from local builds cannot be uploaded to S3."
   rapids-echo-stderr "Open a PR to have successful builds uploaded."
   exit 0
 fi
-
-pkg_name="$(rapids-package-name "wheel_${pkg_type}")"
 
 rapids-upload-to-s3 "${pkg_name}" "$@"

--- a/tools/rapids-upload-wheels-to-s3
+++ b/tools/rapids-upload-wheels-to-s3
@@ -4,12 +4,21 @@
 #   1) wheel path to tar up
 set -e
 
+pkg_type="$1"
+if [ "${pkg_type}" != "cpp" ] && [ "${pkg_type}" != "python" ]; then
+    rapids-echo-error "Wheel cpp packages are now supported."
+    rapids-echo-error "You must specify package type as the first argument to rapids-upload-wheels-to-s3"
+fi
+
+# remove pkg_type from args because we handle it in this script
+shift;
+
 if [ "${CI:-false}" = "false" ]; then
   rapids-echo-stderr "Packages from local builds cannot be uploaded to S3."
   rapids-echo-stderr "Open a PR to have successful builds uploaded."
   exit 0
 fi
 
-pkg_name="$(rapids-package-name wheel_python)"
+pkg_name="$(rapids-package-name wheel_${pkg_type})"
 
 rapids-upload-to-s3 "${pkg_name}" "$@"


### PR DESCRIPTION
This idea comes from a slack DM with Viyas:

> OK, so the first piece I'm thinking of is artifact download. If you look at the raft PR, we have [snippets like this](https://github.com/rapidsai/raft/pull/2251/files#diff-616eb8e64286a9a59a2cd9c77d817fba66ce78ecfdde635db9f4028b74349585R34):
artifact_name=$(RAPIDS_PY_WHEEL_NAME="librmm_${RAPIDS_PY_CUDA_SUFFIX}" RAPIDS_REPOSITORY=rmm RAPIDS_PY_VERSION="3.11" rapids-package-name wheel_python)
commit=$(git ls-remote https://github.com/rapidsai/rmm.git refs/heads/pull-request/1512 | cut -c1-7)
librmm_wheelhouse=$(rapids-get-artifact "ci/rmm/pull-request/1512/${commit}/${artifact_name}")

> The snippet above demonstrates two issues:
There isn't an easy way to download arbitrary PR wheel artifacts. However, [there is such a tool for conda artifacts](https://github.com/rapidsai/gha-tools/blob/main/tools/rapids-get-pr-conda-artifact). That was added in https://github.com/rapidsai/gha-tools/pull/85. What we want is to generalize this tool to work for wheels.
The librmm wheel should not be specific to a particular Python version because it's a pure C++ wheel. However, our current naming scheme on [downloads.rapids.ai](http://downloads.rapids.ai/) doesn't know that. I'm currently hacking it by specifying the RAPIDS_PY_VERSION="3.11". This is working because [I'm restricting the C++ wheel build CI job to only run with Python 3.11](https://github.com/rapidsai/raft/pull/2251/files#diff-1eb4e5fd5611777d4e597ef299a1cb5ba8050c28a2dabbd4fbc56205d69e5ddaR82). There was [another recent gha-tools PR](https://github.com/rapidsai/gha-tools/pull/96) that added support for pure Python wheels. What we want is to generalize this tool to also work for C++ wheels. The main difference is that C++ wheels have to care about arch, whereas pure Python wheels do not

> I think a good starting point would be to make PRs to gha-tools to address the above issues. Does that make sense?

At the time that I'm submitting this, I haven't yet found examples of the wheels_cpp files. Vyas is working on fleshing those out, and I will be taking over that work from him once he gets it on the right track.