### PR TITLE
exclude stable from non-release jobs

### DIFF
--- a/tools/rapids-configure-conda-channels
+++ b/tools/rapids-configure-conda-channels
@@ -5,4 +5,7 @@
 if rapids-is-release-build; then
   conda config --system --remove channels rapidsai-nightly
   conda config --system --remove channels dask/label/dev
+else
+  # exclude stable channel from all non-release builds.
+  conda config --system --remove channels rapidsai
 fi


### PR DESCRIPTION
Excludes the `rapids` stable channel from all non-release jobs to prevent situations such as conda resorting to using an old stable dependency if there are dependency conflicts in the current build.