### PR TITLE
support cpp wheels in 'rapids-wheels-anaconda'

### DIFF
--- a/tools/rapids-wheels-anaconda
+++ b/tools/rapids-wheels-anaconda
@@ -3,6 +3,13 @@
 
 # Positional Arguments:
 #   1) wheel name
+#   2) package type (one of: 'cpp', 'python')
+#
+# [usage]
+#
+#   # upload any wheels found in CI artifacts with names like '*wheel_python_sparkly-unicorn*.tar.gz'
+#   rapids-wheels-anaconda 'sparkly-unicorn' 'python'
+#
 
 set -exou pipefail
 source rapids-constants
@@ -13,8 +20,9 @@ if [ -z "$1" ]; then
   exit 1
 fi
 WHEEL_NAME="$1"
+PKG_TYPE="${2:-python}"
 
-WHEEL_SEARCH_KEY="wheel_python_${WHEEL_NAME}"
+WHEEL_SEARCH_KEY="wheel_${PKG_TYPE}_${WHEEL_NAME}"
 
 WHEEL_DIR="./dist"
 mkdir -p "${WHEEL_DIR}"

--- a/tools/rapids-wheels-anaconda
+++ b/tools/rapids-wheels-anaconda
@@ -22,6 +22,17 @@ fi
 WHEEL_NAME="$1"
 PKG_TYPE="${2:-python}"
 
+case "${PKG_TYPE}" in
+  cpp)
+    ;;
+  python)
+    ;;
+  *)
+    rapids-echo-stderr 'Pass one of the following package types: "cpp", "python"'
+    exit 1
+    ;;
+esac
+
 WHEEL_SEARCH_KEY="wheel_${PKG_TYPE}_${WHEEL_NAME}"
 
 WHEEL_DIR="./dist"

--- a/tools/rapids-wheels-anaconda
+++ b/tools/rapids-wheels-anaconda
@@ -11,7 +11,7 @@
 #   rapids-wheels-anaconda 'sparkly-unicorn' 'python'
 #
 
-set -exou pipefail
+set -eou pipefail
 source rapids-constants
 export RAPIDS_SCRIPT_NAME="rapids-wheels-anaconda"
 


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/44.

Proposes removing hardcoding of `_python_` in the search for artifact names performed by `rapids-wheels-anaconda`, to enable uploading of C++ wheels (which will have `_cpp_` in artifact names).

## Notes for Reviewers

I think this would be safe to merge right now... it should be totally backwards-compatible because it defaults to `_python_` when a `pkg_type` isn't supplied.

To see how the entire S3 object key is computed, also see this:

https://github.com/rapidsai/gha-tools/blob/4c878b81203e29eea312b5774868b83c1b931466/tools/rapids-s3-path#L8-L15

Related to:

* https://github.com/rapidsai/build-planning/issues/57
* https://github.com/rapidsai/ucxx/pull/226
* https://github.com/rapidsai/ucx-wheels/pull/1