### PR TITLE
Allow jobs to be ignored in `rapids-check-pr-job-dependencies`

### DIFF
--- a/tools/rapids-check-pr-job-dependencies
+++ b/tools/rapids-check-pr-job-dependencies
@@ -8,7 +8,7 @@
 #
 # An optional argument can be passed to ignore certain jobs from the check.
 # The argument should be a space-separated list of job names, e.g.:
-#  check-pr-builder-depends.sh "job1 job2 job3"
+#  rapids-check-pr-job-dependencies "job1 job2 job3"
 set -euo pipefail
 
 export WORKFLOW_FILE=${WORKFLOW_FILE:-".github/workflows/pr.yaml"}
@@ -21,7 +21,7 @@ export WORKFLOW_JOBS
 PR_BUILDER_JOB_NEEDS=$(yq '(.jobs.[env(PR_BUILDER_JOB_NAME)].needs)' "${WORKFLOW_FILE}")
 export PR_BUILDER_JOB_NEEDS
 
-IGNORED_JOBS=$(yq -n 'strenv(IGNORED_JOBS) | split(" ")')
+IGNORED_JOBS=$(yq -n 'strenv(IGNORED_JOBS) | trim | split(" ")')
 export IGNORED_JOBS
 
 MISSING_JOBS=$(yq -n '((env(WORKFLOW_JOBS) - env(PR_BUILDER_JOB_NEEDS)) - env(IGNORED_JOBS))')

--- a/tools/rapids-check-pr-job-dependencies
+++ b/tools/rapids-check-pr-job-dependencies
@@ -32,8 +32,8 @@ if yq -en 'env(MISSING_JOBS) | length != 0' >/dev/null 2>&1; then
   yq -n 'env(MISSING_JOBS) | map("  - " + .) | join("\n")'
 
   echo ""
-  echo "Update '${WORKFLOW_FILE}' to include all other jobs for '${PR_BUILDER_JOB_NAME}'".
-  echo "Alternatively, you may ignore certain jobs by passing them as an argument to this script."
+  echo "Update '${WORKFLOW_FILE}' to include these missing jobs for '${PR_BUILDER_JOB_NAME}'".
+  echo "Alternatively, you may ignore these jobs by passing them as an argument to this script."
   exit 1
 fi
 

--- a/tools/rapids-check-pr-job-dependencies
+++ b/tools/rapids-check-pr-job-dependencies
@@ -5,21 +5,35 @@
 # This is necessary since the RAPIDS branch protections are configured to require
 # the "pr-builder" job to pass for all PRs. It's implied that that job depends
 # on all other jobs in the workflow.
+#
+# An optional argument can be passed to ignore certain jobs from the check.
+# The argument should be a space-separated list of job names, e.g.:
+#  check-pr-builder-depends.sh "job1 job2 job3"
 set -euo pipefail
 
 export WORKFLOW_FILE=${WORKFLOW_FILE:-".github/workflows/pr.yaml"}
 export PR_BUILDER_JOB_NAME=${PR_BUILDER_JOB_NAME:-"pr-builder"}
+export IGNORED_JOBS=${1:-""}
 
-WORKFLOW_JOBS=$(yq '((.jobs | keys | sort) - [env(PR_BUILDER_JOB_NAME)]) | join(" ")' "${WORKFLOW_FILE}")
+WORKFLOW_JOBS=$(yq '((.jobs | keys) - [strenv(PR_BUILDER_JOB_NAME)])' "${WORKFLOW_FILE}")
+export WORKFLOW_JOBS
 
-PR_BUILDER_JOB_NEEDS=$(yq '(.jobs.[env(PR_BUILDER_JOB_NAME)].needs | sort) | join(" ")' "${WORKFLOW_FILE}")
+PR_BUILDER_JOB_NEEDS=$(yq '(.jobs.[env(PR_BUILDER_JOB_NAME)].needs)' "${WORKFLOW_FILE}")
+export PR_BUILDER_JOB_NEEDS
 
-if [ "${WORKFLOW_JOBS}" != "${PR_BUILDER_JOB_NEEDS}" ]; then
-  echo "'${PR_BUILDER_JOB_NAME}' is missing a dependency."
-  echo "Update '${WORKFLOW_FILE}' to include all other jobs for '${PR_BUILDER_JOB_NAME}'"
+IGNORED_JOBS=$(yq -n 'strenv(IGNORED_JOBS) | split(" ")')
+export IGNORED_JOBS
+
+MISSING_JOBS=$(yq -n '((env(WORKFLOW_JOBS) - env(PR_BUILDER_JOB_NEEDS)) - env(IGNORED_JOBS))')
+export MISSING_JOBS
+
+if yq -en 'env(MISSING_JOBS) | length != 0' >/dev/null 2>&1; then
+  echo "'${PR_BUILDER_JOB_NAME}' job is missing the following dependent jobs:"
+  yq -n 'env(MISSING_JOBS) | map("  - " + .) | join("\n")'
+
   echo ""
-  echo "Workflow jobs: ${WORKFLOW_JOBS}"
-  echo "'${PR_BUILDER_JOB_NAME}' job dependencies: ${PR_BUILDER_JOB_NEEDS}"
+  echo "Update '${WORKFLOW_FILE}' to include all other jobs for '${PR_BUILDER_JOB_NAME}'".
+  echo "Alternatively, you may ignore certain jobs by passing them as an argument to this script."
   exit 1
 fi
 


### PR DESCRIPTION
The `rapids-check-pr-job-dependencies` script is responsible for ensuring that the `pr-builder` job used by RAPIDS depends on all other jobs in the `pr.yaml` workflow. This is important because the `pr-builder` job is the only job that RAPIDS requires to pass before merging.

Previously, there was no way to ignore certain jobs from this check. This made it difficult to add optional jobs to the `pr.yaml` workflow.

This PR addresses that issue by allowing the `rapids-check-pr-job-dependencies` script to accept a positional argument of space-delimited job names that should be ignored.

The argument can be used like this:

```sh
check-pr-builder-depends.sh "job1 job2 job3"
```

It is intended to be used in our shared workflows like this:

```yaml
- name: Check workflow file dependencies
  if: ${{ inputs.enable_check_pr_job_dependencies }}
  run: rapids-check-pr-job-dependencies "${IGNORED_JOBS}"
  env:
    IGNORED_JOBS: ${{ inputs.ignored_jobs }}
```

It can then be used by calling repositories like this:

```yaml
jobs:
  checks:
    secrets: inherit
    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.06
    with:
      ignored_jobs: >-
        job1
        job2
        conda-cpp-tests
        conda-python-tests
```