### PR TITLE
re-enable stable channel for non-release builds

### DIFF
--- a/tools/rapids-configure-conda-channels
+++ b/tools/rapids-configure-conda-channels
@@ -24,7 +24,4 @@ remove_conda_channel() {
 if rapids-is-release-build; then
   remove_conda_channel 'rapidsai-nightly'
   remove_conda_channel 'dask/label/dev'
-else
-  # exclude stable channel from all non-release builds.
-  remove_conda_channel 'rapidsai'
 fi


### PR DESCRIPTION
We identified a problem with the initial removal of the channel, completed in #102. 

The issue arises particularly in the case of hotfixes, where we need dependencies from earlier or older RAPIDS versions. These are usually only available in the stable `rapidsai` channel, considering we routinely clean up old packages from our nightly channel.

So, this PR reverts the exclusion of the stable channel from non-release builds. This ensures that during a hotfix, dependencies are available and can be resolved.