### PR TITLE
Always set a default value for `PARALLEL_LEVEL` in `rapids-configure-sccache`

### DIFF
--- a/tools/rapids-configure-sccache
+++ b/tools/rapids-configure-sccache
@@ -1,17 +1,18 @@
 #!/bin/bash
 # A utility script that configures sccache environment variables
 
-  export CMAKE_CUDA_COMPILER_LAUNCHER=sccache
-  export CMAKE_CXX_COMPILER_LAUNCHER=sccache
-  export CMAKE_C_COMPILER_LAUNCHER=sccache
-  export SCCACHE_BUCKET=rapids-sccache-east
-  export SCCACHE_REGION=us-east-2
-  export SCCACHE_IDLE_TIMEOUT=32768
-  export SCCACHE_S3_USE_SSL=true
-  export SCCACHE_S3_NO_CREDENTIALS=false
+export CMAKE_CUDA_COMPILER_LAUNCHER=sccache
+export CMAKE_CXX_COMPILER_LAUNCHER=sccache
+export CMAKE_C_COMPILER_LAUNCHER=sccache
+export PARALLEL_LEVEL=${PARALLEL_LEVEL:-$(nproc --all --ignore=2)}
+export SCCACHE_BUCKET=rapids-sccache-east
+export SCCACHE_IDLE_TIMEOUT=32768
+export SCCACHE_REGION=us-east-2
+export SCCACHE_S3_NO_CREDENTIALS=false
+export SCCACHE_S3_USE_SSL=true
+
 if [ "${CI:-false}" = "false" ]; then
   # Configure sccache for read-only mode since no credentials
   # are available in local builds.
   export SCCACHE_S3_NO_CREDENTIALS=true
-  export PARALLEL_LEVEL=${PARALLEL_LEVEL:-$(nproc)}
 fi


### PR DESCRIPTION
This will ensure the `PARALLEL_LEVEL` variable is defined to a suitable value and that RAPIDS projects don't depend on the runner to define this variable.

Fixes https://github.com/rapidsai/build-planning/issues/66