### PR TITLE
Make `rapids-print-env` compatible with non-`conda` images

### DIFF
--- a/tools/rapids-print-env
+++ b/tools/rapids-print-env
@@ -13,7 +13,7 @@ arch
 rapids-logger "Check python version"
 python --version
 
-if conda &> /dev/null; then
+if command -v conda > /dev/null; then
   rapids-logger "Check conda environment"
   conda info
   conda config --show-sources

--- a/tools/rapids-print-env
+++ b/tools/rapids-print-env
@@ -13,7 +13,9 @@ arch
 rapids-logger "Check python version"
 python --version
 
-rapids-logger "Check conda environment"
-conda info
-conda config --show-sources
-conda list --show-channel-urls
+if conda &> /dev/null; then
+  rapids-logger "Check conda environment"
+  conda info
+  conda config --show-sources
+  conda list --show-channel-urls
+fi


### PR DESCRIPTION
This PR ensures that the `rapids-print-env` command is compatible with non-`conda` CI images.

This ensures the command can be run in `ci-wheel` images.