### PR TITLE
consider all tag refs builds as release builds

### DIFF
--- a/tools/rapids-is-release-build
+++ b/tools/rapids-is-release-build
@@ -8,7 +8,7 @@
 set -e
 export RAPIDS_SCRIPT_NAME="rapids-is-release-build"
 
-if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+if [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   rapids-echo-stderr "is release build"
   exit 0
 fi

--- a/tools/rapids-is-release-build
+++ b/tools/rapids-is-release-build
@@ -8,9 +8,10 @@
 set -e
 export RAPIDS_SCRIPT_NAME="rapids-is-release-build"
 
-if [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9]{1,2}.[0-9]{2}.[0-9]{2}$ ]]; then
+if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
   rapids-echo-stderr "is release build"
   exit 0
 fi
+
 rapids-echo-stderr "is not release build"
 exit 1


### PR DESCRIPTION
This PR updates the `rapids-is-release-build` tool to mark all builds triggered from tag refs as release builds.

All RAPIDS libraries releases are currently triggered via tags. Other repositories such as `pynvjitlink`, `rapids-build-backend`, `rapids-metadata`, `ucxx`, `ucx-py`, `jupyterlab-nvdashboard` have only their releases triggered via tags as well so this shouldn't break anything.

cc; @raydouglass