### PR TITLE
Collect `.conda` packages in `glob` for upload

### DIFF
--- a/tools/rapids-find-anaconda-uploads.py
+++ b/tools/rapids-find-anaconda-uploads.py
@@ -64,7 +64,7 @@ def file_filter_fn(file_path):
 
 if __name__ == "__main__":
     directory_to_search = sys.argv[1]
-    tar_files = glob.glob(f"{directory_to_search}/**/*.tar.bz2", recursive=True)
+    conda_pkgs = glob.glob(f"{directory_to_search}/**/*.tar.bz2", recursive=True)
 
-    filtered_list = list(filter(file_filter_fn, tar_files))
+    filtered_list = list(filter(file_filter_fn, conda_pkgs))
     print("\n".join(filtered_list))

--- a/tools/rapids-find-anaconda-uploads.py
+++ b/tools/rapids-find-anaconda-uploads.py
@@ -65,6 +65,7 @@ def file_filter_fn(file_path):
 if __name__ == "__main__":
     directory_to_search = sys.argv[1]
     conda_pkgs = (
+        glob.glob(f"{directory_to_search}/**/*.conda", recursive=True) +
         glob.glob(f"{directory_to_search}/**/*.tar.bz2", recursive=True)
     )
 

--- a/tools/rapids-find-anaconda-uploads.py
+++ b/tools/rapids-find-anaconda-uploads.py
@@ -64,7 +64,9 @@ def file_filter_fn(file_path):
 
 if __name__ == "__main__":
     directory_to_search = sys.argv[1]
-    conda_pkgs = glob.glob(f"{directory_to_search}/**/*.tar.bz2", recursive=True)
+    conda_pkgs = (
+        glob.glob(f"{directory_to_search}/**/*.tar.bz2", recursive=True)
+    )
 
     filtered_list = list(filter(file_filter_fn, conda_pkgs))
     print("\n".join(filtered_list))


### PR DESCRIPTION
Part of issue: https://github.com/rapidsai/build-planning/issues/98

Add a `glob` expression for `.conda` packages in addition to the expression for `.tar.bz2`. This way either format can be uploaded.