### PR TITLE
introduce rapids-generate-pip-constraints

### DIFF
--- a/tools/rapids-generate-pip-constraints
+++ b/tools/rapids-generate-pip-constraints
@@ -18,14 +18,20 @@
 
 set -euo pipefail
 
+export RAPIDS_SCRIPT_NAME="rapids-generate-pip-constraints"
+
 file_key="${1}"
 out_file="${2}"
 
-echo "" > "${out_file}"
 if [[ "${RAPIDS_DEPENDENCIES}" == "oldest" ]]; then
     rapids-dependency-file-generator \
         --output requirements \
         --file-key "${file_key}" \
         --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES}" \
     | tee "${out_file}"
+elif [[ "${RAPIDS_DEPENDENCIES}" == "latest" ]]; then
+    echo "" > "${out_file}"
+else
+    rapids-echo-stderr "Got unrecognized value for RAPIDS_DEPENDENCIES: '${RAPIDS_DEPENDENCIES}'. Expected one of ('latest', 'oldest')."
+    exit 1
 fi

--- a/tools/rapids-generate-pip-constraints
+++ b/tools/rapids-generate-pip-constraints
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Write out a constraints.txt file for use with 'pip'.
+#
+# For more context:
+#  * https://github.com/rapidsai/shared-workflows/pull/228
+#  * https://github.com/rapidsai/cudf/pull/16570#discussion_r1735300231
+#
+# Positional arguments:
+#
+#    1) file key to be passed to `rapids-dependency-file-generator --file-key`
+#    2) filepath to write the constraint data to
+#
+# [usage]
+#
+#   rapids-generate-pip-constraints test_python ./constraints.txt
+#
+
+set -euo pipefail
+
+file_key="${1}"
+out_file="${2}"
+
+echo "" > "${out_file}"
+if [[ "${RAPIDS_DEPENDENCIES}" == "oldest" ]]; then
+    rapids-dependency-file-generator \
+        --output requirements \
+        --file-key "${file_key}" \
+        --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES}" \
+    | tee "${out_file}"
+fi


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/81

https://github.com/rapidsai/shared-workflows/pull/228 introduced a new environment variable for wheel-testing CI jobs, `RAPIDS_DEPENDENCIES`, which takes the following values:

* `oldest` = pin to oldest-supported versions
* `latest` = do not constraint versions

To take advantage of that in CI, PRs like https://github.com/rapidsai/cudf/pull/16570 have been rolling out. They're all taking a similar approach, copying around the same snippet of code that generates a pip `constraints.txt` file using `rapids-dependency-file-generator`.

Based on the suggestion from https://github.com/rapidsai/cudf/pull/16570#discussion_r1735300231, this proposes wrapping that behavior in a tool.

## Notes for Reviewers

### Benefits of this change

Simplifies and standardizes CI scripts.

Reduces the effort to roll out other types of testing with alternative dependency sets in the future.

### How I tested this

With latest `cudf` (including the changes from https://github.com/rapidsai/cudf/pull/16570) checked out, ran the following from the root of that repo:

```shell
PATH="${HOME}/repos/gha-tools/tools:${PATH}" \
RAPIDS_CUDA_VERSION="12.5.1" \
RAPIDS_DEPENDENCIES=latest \
RAPIDS_PY_VERSION="3.11" \
  ${GHA_TOOLS}/rapids-generate-pip-constraints \
      test_python \
      ./beep-boop.txt
      
cat ./beep-boop.txt
# (empty)

PATH="${HOME}/repos/gha-tools/tools:${PATH}" \
RAPIDS_CUDA_VERSION="12.5.1" \
RAPIDS_DEPENDENCIES=oldest \
RAPIDS_PY_VERSION="3.11" \
  ${GHA_TOOLS}/rapids-generate-pip-constraints \
      test_python \
      ./beep-boop.txt

# # This file is generated by `rapids-dependency-file-generator`.
# # To make changes, edit ../dependencies.yaml and run `rapids-dependency-file-generator`.
# cramjam
# cupy-cuda11x==12.0.0
# cupy-cuda12x==12.0.0
# cupy==12.0.0
# dask-cuda==24.10.*,>=0.0.0a0
# ...

PATH="${HOME}/repos/gha-tools/tools:${PATH}" \
RAPIDS_CUDA_VERSION="12.5.1" \
RAPIDS_DEPENDENCIES=oldset \
RAPIDS_PY_VERSION="3.11" \
  ${GHA_TOOLS}/rapids-generate-pip-constraints \
      test_python \
      ./beep-boop.txt
# [rapids-generate-pip-constraints] Got unrecognized value for RAPIDS_DEPENDENCIES: 'oldset'. Expected one of ('latest', 'oldest').

echo $?
# 1
```