### PR TITLE
Retry on DependencyNeedsBuildingError.

### DIFF
--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -96,6 +96,9 @@ function runConda {
         elif grep -q ConnectionError: "${outfile}"; then
             retryingMsg="Retrying, found 'ConnectionError:' in output..."
             needToRetry=1
+        elif grep -q DependencyNeedsBuildingError: "${outfile}"; then
+            retryingMsg="Retrying, found 'DependencyNeedsBuildingError:' in output..."
+            needToRetry=1
         elif grep -q EOFError: "${outfile}"; then
             retryingMsg="Retrying, found 'EOFError:' in output..."
             needToRetry=1
@@ -120,6 +123,7 @@ function runConda {
 'CondaMultiError:', \
 'Connection broken:', \
 'ConnectionError:', \
+'DependencyNeedsBuildingError:', \
 'EOFError:', \
 'JSONDecodeError:', \
 'Multi-download failed', \


### PR DESCRIPTION
Lately there have been a number of CI failures due to network issues that have the error `DependencyNeedsBuildingError`. I think this is new behavior (possibly a new conda version), so we have not accounted for it in `rapids-conda-retry` before.

Example: https://github.com/rapidsai/raft/actions/runs/10775513053/job/29882470729?pr=2428

The important note here is that a compatible `librmm 24.10.*` _does_ exist, as far as I can tell, but it appears that the channel metadata for `rapidsai` was not properly downloaded. Retrying the job fixes this error.
```
...

RuntimeError: Solver could not find solution.Mamba failed to solve:
 - rapids-build-backend >=0.3.0,<0.4.0.dev0
 - cython >=3.0.0
 - cuda-cudart-dev
 - scikit-build-core >=0.10.0
 - python 3.11.*
 - libraft 24.10.00a32
 - rmm 24.10.*
 - cuda-version 12.5.*
 - cuda-python >=12.0,<13.0a0
 - libraft-headers 24.10.00a32

with channels:
 - file:///tmp/cpp_channel
 - file:///tmp/conda-bld-output

The reported errors are:
- Encountered problems while solving:
-   - nothing provides requested rmm 24.10.*
-   - nothing provides librmm 24.10.* needed by libraft-headers-24.10.00a32-cuda12_240909_gd475832a_32
-   - nothing provides librmm 24.10.* needed by libraft-headers-24.10.00a32-cuda12_240909_gd475832a_32
-

...

conda_build.exceptions.DependencyNeedsBuildingError: Unsatisfiable dependencies for platform linux-aarch64: {MatchSpec("librmm=24.10"), MatchSpec("libraft-headers==24.10.00a32=cuda12_240909_gd475832a_32"), MatchSpec("rmm=24.10")}
[rapids-conda-retry] conda returned exit code: 1
[rapids-conda-retry] Exiting, no retryable conda errors detected: 'ChecksumMismatchError:', 'ChunkedEncodingError:', 'CondaHTTPError:', 'CondaMultiError:', 'Connection broken:', 'ConnectionError:', 'EOFError:', 'JSONDecodeError:', 'Multi-download failed', 'Timeout was reached', segfault exit code 139

...
```
