### PR TITLE
update update-version.sh to use packaging lib

### DIFF
--- a/tools/rapids-pip-wheel-version
+++ b/tools/rapids-pip-wheel-version
@@ -12,7 +12,7 @@ fi
 epoch_timestamp="$1"
 
 function distutilsNormalizeVersion {
-        echo -n "$(python3 -c "from setuptools.extern import packaging; print(packaging.version.Version('$1'))")"
+        echo -n "$(python3 -c "from packaging.version import Version; print(Version('$1'))")"
 }
 
 rapids-echo-stderr "pwd is $(pwd)"


### PR DESCRIPTION
This PR updates the update-version.sh script to use the packaging library, given that setuptools is no longer included by default in Python 3.12.