### PR TITLE
consider .conda files in rapids-extract-conda-files

### DIFF
--- a/tools/rapids-extract-conda-files
+++ b/tools/rapids-extract-conda-files
@@ -15,6 +15,6 @@ tarball_dir="$1"
   untar_dest=$(mktemp -d)
   mkdir -p "${untar_dest}"
   cd "${untar_dest}"
-  find "${tarball_dir}" -name "*tar.bz2" -type f -print0 | xargs -0 -n 1 tar -v -xf
+  find "${tarball_dir}" \( -name "*.tar.bz2" -o -name "*.conda" \) -type f -print0 | xargs -0 -n 1 cph extract --dest .
 } >&2
 echo -n "${untar_dest}"


### PR DESCRIPTION
Related to https://github.com/rapidsai/shared-workflows/issues/250

Starting with https://github.com/rapidsai/ci-imgs/pull/176, RAPIDS projects are producing `.conda`-formatted conda packages. That breaks the `conda-cpp-checks` CI workflow because the `rapids-extract-conda-files` tool here only considers `.tar.bz2` files.

https://github.com/rapidsai/ci-imgs/pull/197 adds the `cph` tool to all the CI images.

This PR uses it to extract the contents of files. 

## Notes for Reviewers

### How I tested this

Put the content of `rapids-extract-conda-files` as of this PR at the working directory I ran `docker run` from.

Then ran the following, with `RAPIDS_*` values set from a PR where we saw the failure: https://github.com/rapidsai/raft/pull/2470

```shell
docker run \
    --rm \
    -v $(pwd):/opt/work \
    -w /opt/work \
    --network host \
    --env RAPIDS_BUILD_TYPE=pull-request \
    --env RAPIDS_SHA=51cdd7d0e08ee7facb10432b7a0899312d678faf\
    --env RAPIDS_PR_NUMBER=2470 \
    --env RAPIDS_REPOSITORY=rapidsai/raft \
    --env RAPIDS_REF_NAME=pull-request/2470 \
    -it rapidsai/ci-wheel:latest \
    bash

CPP_DIR=$(rapids-download-conda-from-s3 cpp)
EXTRACTED_DIR=$(./rapids-extract-conda-files "${CPP_DIR}")
```

Saw that succeed, and the package be extracted to exactly where we want it to be:

```shell
ls "${EXTRACTED_DIR}"
# bin  include  info  lib  test

ls "${EXTRACTED_DIR}/lib"
# cmake  libraft.a  libraft.so
```