### PR TITLE
Update naming conventions in `tools/rapids-extract-conda-files`

### DIFF
--- a/tools/rapids-extract-conda-files
+++ b/tools/rapids-extract-conda-files
@@ -5,16 +5,16 @@ set -eo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-extract-conda-files"
 
 if [ -z "$1" ]; then
-  rapids-echo-stderr "Must specify input argument: TARBALL_DIR"
+  rapids-echo-stderr "Must specify input argument: CONDA_PKG_DIR"
   exit 1
 fi
 
 # dir that the extracted tarball are in
-tarball_dir="$1"
+conda_pkg_dir="$1"
 {
   untar_dest=$(mktemp -d)
   mkdir -p "${untar_dest}"
   cd "${untar_dest}"
-  find "${tarball_dir}" \( -name "*.tar.bz2" -o -name "*.conda" \) -type f -print0 | xargs -0 -n 1 cph extract --dest .
+  find "${conda_pkg_dir}" \( -name "*.tar.bz2" -o -name "*.conda" \) -type f -print0 | xargs -0 -n 1 cph extract --dest .
 } >&2
 echo -n "${untar_dest}"

--- a/tools/rapids-extract-conda-files
+++ b/tools/rapids-extract-conda-files
@@ -12,9 +12,9 @@ fi
 # dir that the extracted tarball are in
 conda_pkg_dir="$1"
 {
-  untar_dest=$(mktemp -d)
-  mkdir -p "${untar_dest}"
-  cd "${untar_dest}"
+  conda_pkg_dest=$(mktemp -d)
+  mkdir -p "${conda_pkg_dest}"
+  cd "${conda_pkg_dest}"
   find "${conda_pkg_dir}" \( -name "*.tar.bz2" -o -name "*.conda" \) -type f -print0 | xargs -0 -n 1 cph extract --dest .
 } >&2
-echo -n "${untar_dest}"
+echo -n "${conda_pkg_dest}"

--- a/tools/rapids-extract-conda-files
+++ b/tools/rapids-extract-conda-files
@@ -9,7 +9,7 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-# dir that the extracted tarball are in
+# dir that the extracted conda packages are in
 conda_pkg_dir="$1"
 {
   conda_pkg_dest=$(mktemp -d)


### PR DESCRIPTION
Part of issue: https://github.com/rapidsai/shared-workflows/issues/250

Follow up to PR: https://github.com/rapidsai/gha-tools/pull/122

In `tools/rapids-extract-conda-files`, rename variables to clarify they refer to Conda packages in either form (`.tar.bz2` or `.conda`). Also update comments similarly. This follows up to work that added `.conda` support in this script