### PR TITLE
Check if in CI before running rapids-package-name

### DIFF
--- a/tools/rapids-upload-wheels-to-s3
+++ b/tools/rapids-upload-wheels-to-s3
@@ -4,6 +4,12 @@
 #   1) wheel path to tar up
 set -e
 
+if [ "${CI:-false}" = "false" ]; then
+  rapids-echo-stderr "Packages from local builds cannot be uploaded to S3."
+  rapids-echo-stderr "Open a PR to have successful builds uploaded."
+  exit 0
+fi
+
 # For legacy reasons, allow this script to be run without the pkg_type being the first arg
 pkg_name="$(rapids-package-name "wheel_python")"
 
@@ -12,12 +18,6 @@ if [ "${pkg_type}" = "cpp" ] || [ "${pkg_type}" = "python" ]; then
     # remove pkg_type from args because we handle it in this script
     shift;
     pkg_name="$(rapids-package-name "wheel_${pkg_type}")"
-fi
-
-if [ "${CI:-false}" = "false" ]; then
-  rapids-echo-stderr "Packages from local builds cannot be uploaded to S3."
-  rapids-echo-stderr "Open a PR to have successful builds uploaded."
-  exit 0
 fi
 
 rapids-upload-to-s3 "${pkg_name}" "$@"


### PR DESCRIPTION
rapids-package-name expects the various variables set in CI to exist to work (and there's no reason to prompt for those locally like we do when downloading since we'll never upload anyway).