### PR TITLE
Retry on CondaSSLError.

### DIFF
--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -92,6 +92,9 @@ function runConda {
             retryingMsg="Retrying after cleaning tarball cache, found 'CondaMultiError:' in output..."
             needToRetry=1
             needToClean=1
+        elif grep -q CondaSSLError: "${outfile}"; then
+            retryingMsg="Retrying, found 'CondaSSLError:' in output..."
+            needToRetry=1
         elif grep -q "Connection broken:" "${outfile}"; then
             retryingMsg="Retrying, found 'Connection broken:' in output..."
             needToRetry=1
@@ -123,6 +126,7 @@ function runConda {
 'ChunkedEncodingError:', \
 'CondaHTTPError:', \
 'CondaMultiError:', \
+'CondaSSLError:', \
 'Connection broken:', \
 'ConnectionError:', \
 'DependencyNeedsBuildingError:', \


### PR DESCRIPTION
### Description

This PR will retry conda commands on `CondaSSLError`.

### Context

We have recently seen more SSL errors, like those we attempted to fix in https://github.com/rapidsai/cuml/pull/6177 and https://github.com/rapidsai/cugraph/pull/4825. However, we still observe SSL errors while downloading conda packages.

Errors look like this:

```
CondaSSLError: Encountered an SSL error. Most likely a certificate verification issue.

Exception: [SYS] unknown error (_ssl.c:2580)
```

In https://github.com/conda/conda/pull/11564, `CondaSSLError` was split from `CondaHTTPError`. This was released in conda 4.14.0.

Currently it appears that all the errors in cuML's CI ([sample nightly run](https://github.com/rapidsai/cuml/actions/runs/12328191653)) are either `CondaSSLError` or actual test failures (some are from Hypothesis, some are not). I hope this PR eliminates the `CondaSSLError` cases.

### Alternatives

From https://stackoverflow.com/questions/31729076/conda-ssl-error, it seems there may be alternative solutions. I think we should add this retry either way, but we may be able to do more.

- Setting `ssl_verify: false` in the conda config
- Maybe we need to add/set a root certificate in the CI images?
- Maybe we need to install a newer `certifi` in the `ci-conda` images? The preinstalled version is currently `2024.8.30` and running `mamba update -n base certifi` updates it to `2024.12.14`. There could be certificate changes in those 4 months.
  - Testing this here: https://github.com/rapidsai/ci-imgs/pull/218
- More ideas: https://docs.conda.io/projects/conda/en/stable/user-guide/configuration/non-standard-certs.html
