### PR TITLE
Allow test package uploads

### DIFF
--- a/tests/test_rapids-find-anaconda-uploads.py
+++ b/tests/test_rapids-find-anaconda-uploads.py
@@ -37,20 +37,6 @@ def test_get_pkg_name_from_filename(filename, pkg_name):
 
 
 @pytest.mark.parametrize(
-    "pkg_name, result",
-    [
-        ("custreamz", False),
-        ("strings_udf", False),
-        ("dask-cudf", False),
-        ("", False),
-        ("libcudf-tests", True),
-    ],
-)
-def test_is_test_pkg(pkg_name, result):
-    assert mod.is_test_pkg(pkg_name) == result
-
-
-@pytest.mark.parametrize(
     "env_var, pkg_name, result",
     [
         ("", "custreamz", False),
@@ -114,7 +100,9 @@ def test_file_filter_fn():
             "./cudf_conda_python_cuda11_38_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
             "./cudf_conda_python_cuda11_38_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
             "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
+            "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-tests-23.02.00a-cuda11_g10bab945_72.tar.bz2",
             "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
+            "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-tests-23.02.00a-cuda11_g10bab945_72.tar.bz2",
         ]
 
     # w/ no env var
@@ -129,5 +117,7 @@ def test_file_filter_fn():
         "./cudf_conda_python_cuda11_38_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
         "./cudf_conda_python_cuda11_38_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
         "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
+        "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-tests-23.02.00a-cuda11_g10bab945_72.tar.bz2",
         "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
+        "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-tests-23.02.00a-cuda11_g10bab945_72.tar.bz2",
     ]

--- a/tests/test_rapids-find-anaconda-uploads.py
+++ b/tests/test_rapids-find-anaconda-uploads.py
@@ -99,10 +99,10 @@ def test_file_filter_fn():
             "./cudf_conda_python_cuda11_39_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
             "./cudf_conda_python_cuda11_38_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
             "./cudf_conda_python_cuda11_38_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-            "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
             "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-tests-23.02.00a-cuda11_g10bab945_72.tar.bz2",
-            "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
+            "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
             "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-tests-23.02.00a-cuda11_g10bab945_72.tar.bz2",
+            "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
         ]
 
     # w/ no env var
@@ -116,8 +116,8 @@ def test_file_filter_fn():
         "./cudf_conda_python_cuda11_39_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
         "./cudf_conda_python_cuda11_38_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
         "./cudf_conda_python_cuda11_38_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-        "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
         "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-tests-23.02.00a-cuda11_g10bab945_72.tar.bz2",
-        "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
+        "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
         "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-tests-23.02.00a-cuda11_g10bab945_72.tar.bz2",
+        "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
     ]

--- a/tools/rapids-find-anaconda-uploads.py
+++ b/tools/rapids-find-anaconda-uploads.py
@@ -54,8 +54,6 @@ def file_filter_fn(file_path):
     filename = path.basename(file_path)
     pkg_name = get_pkg_name_from_filename(filename)
 
-    if is_test_pkg(pkg_name):
-        return False
     if is_skip_pkg(pkg_name):
         return False
 

--- a/tools/rapids-find-anaconda-uploads.py
+++ b/tools/rapids-find-anaconda-uploads.py
@@ -29,14 +29,6 @@ def get_pkg_name_from_filename(filename):
     return "-".join(filename.split("-")[:-2])
 
 
-def is_test_pkg(pkg_name):
-    """
-    Returns true if the package name matches the pattern we use for
-    gtest packages.
-    """
-    return pkg_name.endswith("-tests")
-
-
 def is_skip_pkg(pkg_name):
     """
     Returns true if the package name is in the "SKIP_UPLOAD_PKGS"


### PR DESCRIPTION
Allow for test conda packages to be uploaded to make it easier for users to run tests or benchmarks.