### PR TITLE
Retry on "Response ended prematurely"

### DIFF
--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -113,6 +113,9 @@ function runConda {
         elif grep -q "Multi-download failed" "${outfile}"; then
             retryingMsg="Retrying, found 'Multi-download failed' in output..."
             needToRetry=1
+        elif grep -q "Response ended prematurely" "${outfile}"; then
+            retryingMsg="Retrying, found 'Response ended prematurely' in output..."
+            needToRetry=1
         elif grep -q "Timeout was reached" "${outfile}"; then
             retryingMsg="Retrying, found 'Timeout was reached' in output..."
             needToRetry=1
@@ -133,6 +136,7 @@ function runConda {
 'EOFError:', \
 'JSONDecodeError:', \
 'Multi-download failed', \
+'Response ended prematurely', \
 'Timeout was reached', \
 segfault exit code 139"
         fi


### PR DESCRIPTION
Fixing failure reported by @pentschev:

> I’ve been seeing the following error quite frequently in nightlies (at least once a day):
[…] Runs where this happened over the last 3 days: https://github.com/rapidsai/ucxx/actions/runs/12407605240/job/34637880542 (https://github.com/rapidsai/ucxx/actions/runs/12407605240/job/34637875540), https://github.com/rapidsai/ucxx/actions/runs/12426811320/job/34695652105, https://github.com/rapidsai/ucxx/actions/runs/12442882583/job/34741487231.