### PR TITLE
Retry 'Unexpected error [0-9]* on netlink descriptor [0-9]*'

### DIFF
--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -119,7 +119,7 @@ function runConda {
         elif grep -q "Timeout was reached" "${outfile}"; then
             retryingMsg="Retrying, found 'Timeout was reached' in output..."
             needToRetry=1
-        elif grep -q "Unexpected error [0-9]* on netlink descriptor [0-9]*" "${outfile}"; then
+        elif grep -q "Unexpected error [0-9]+ on netlink descriptor [0-9]+" "${outfile}"; then
             retryingMsg="Retrying, found 'Unexpected error [0-9]* on netlink descriptor [0-9]*' in output..."
             needToRetry=1
         elif [[ $exitcode -eq 139 ]]; then

--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -119,6 +119,9 @@ function runConda {
         elif grep -q "Timeout was reached" "${outfile}"; then
             retryingMsg="Retrying, found 'Timeout was reached' in output..."
             needToRetry=1
+        elif grep -q "Unexpected error [0-9]* on netlink descriptor [0-9]*" "${outfile}"; then
+            retryingMsg="Retrying, found 'Unexpected error [0-9]* on netlink descriptor [0-9]*' in output..."
+            needToRetry=1
         elif [[ $exitcode -eq 139 ]]; then
             retryingMsg="Retrying, command resulted in a segfault. This may be an intermittent failure..."
             needToRetry=1
@@ -138,6 +141,7 @@ function runConda {
 'Multi-download failed', \
 'Response ended prematurely', \
 'Timeout was reached', \
+'Unexpected error [0-9]* on netlink descriptor [0-9]*', \
 segfault exit code 139"
         fi
 


### PR DESCRIPTION
Recently we have had several nightly failures due to network issues. These errors appeared as:

https://github.com/rapidsai/ucxx/actions/runs/13067745825/job/36462909749#step:8:3868
```
Unexpected error 9 on netlink descriptor 7.
```

https://github.com/rapidsai/rmm/actions/runs/13066928144/job/36460789434#step:8:1600
```
Unexpected error 9 on netlink descriptor 9.
```

This has come up before, as well. See the following links:
- https://github.com/rapidsai/ci-imgs/issues/228#issuecomment-2597141388
- https://github.com/rapidsai/ci-imgs/issues/162#issuecomment-2596845806
- https://github.com/rapidsai/cudf/pull/17585#pullrequestreview-2512061190
- https://github.com/rapidsai/ci-imgs/pull/219#issuecomment-2596481942

@jameslamb has [pointed to a potential root cause](https://github.com/rapidsai/ci-imgs/pull/219#issuecomment-2596490603):

> I found a couple discussions on the internet suggesting that that particular error can come from non-thread-safe handling of file descriptors:
> - https://github.com/curl/curl/issues/3386#issuecomment-455840319
> - https://stackoverflow.com/a/59615786/3986677

At this point it seems like retrying is the best solution we have available.
