### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# CI code owners
+* @rapidsai/ci-codeowners


### PR DESCRIPTION
CODEOWNERS were not defined for this repo. I added the CI team.
