### PR TITLE
Retry on 'Error when extracting package:' and 'File not valid: SHA256 sum doesn't match expectation'

### DIFF
--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -110,6 +110,9 @@ function runConda {
         elif grep -q "Error when extracting package:" "${outfile}"; then
             retryingMsg="Retrying, found 'Error when extracting package:' in output..."
             needToRetry=1
+        elif grep -q "File not valid: SHA256 sum doesn't match expectation" "${outfile}"; then
+            retryingMsg="Retrying, found 'File not valid: SHA256 sum doesn't match expectation' in output..."
+            needToRetry=1
         elif grep -q JSONDecodeError: "${outfile}"; then
             retryingMsg="Retrying, found 'JSONDecodeError:' in output..."
             needToRetry=1
@@ -141,6 +144,7 @@ function runConda {
 'DependencyNeedsBuildingError:', \
 'EOFError:', \
 'Error when extracting package:', \
+'File not valid: SHA256 sum doesn't match expectation', \
 'JSONDecodeError:', \
 'Multi-download failed', \
 'Response ended prematurely', \

--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -107,6 +107,9 @@ function runConda {
         elif grep -q EOFError: "${outfile}"; then
             retryingMsg="Retrying, found 'EOFError:' in output..."
             needToRetry=1
+        elif grep -q "Error when extracting package:" "${outfile}"; then
+            retryingMsg="Retrying, found 'Error when extracting package:' in output..."
+            needToRetry=1
         elif grep -q JSONDecodeError: "${outfile}"; then
             retryingMsg="Retrying, found 'JSONDecodeError:' in output..."
             needToRetry=1
@@ -137,6 +140,7 @@ function runConda {
 'ConnectionError:', \
 'DependencyNeedsBuildingError:', \
 'EOFError:', \
+'Error when extracting package:', \
 'JSONDecodeError:', \
 'Multi-download failed', \
 'Response ended prematurely', \


### PR DESCRIPTION
I am seeing failures in NVKS CI, which looks like network errors. Because this is our first time testing the new NVKS cluster, it is possible that the network failure modes will look a bit different on the new cluster than what we've seen previously.

https://github.com/rapidsai/cucim/actions/runs/13076589622/job/36491216800?pr=817#step:8:3003
```
error    libmamba Error opening for reading "/opt/conda/pkgs/fastrlock-0.8.3-py312h6edf5ed_1/info/index.json": No such file or directory
fastrlock-0.8.3-py312h6edf5ed_1.conda extraction failed
error    libmamba Error when extracting package: [json.exception.parse_error.101] parse error at line 1, column 1: attempting to parse an empty input; check that your input string or stream contains the expected JSON
Found incorrect download: fastrlock. Aborting
```

https://github.com/rapidsai/cuml/actions/runs/13076599723/job/36492358833?pr=6280#step:10:3477
```
toolz-1.0.0-pyhd8ed1ab_1.conda tarball has incorrect checksum
error    libmamba File not valid: SHA256 sum doesn't match expectation "/opt/conda/pkgs/toolz-1.0.0-pyhd8ed1ab_1.conda"
    Expected: eda38f423c33c2eaeca49ed946a8d3bf466cc3364970e083a65eb2fd85258d87
    Actual: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```
