### PR TITLE
record file sizes for telemetry

### DIFF
--- a/tools/rapids-upload-artifacts-dir
+++ b/tools/rapids-upload-artifacts-dir
@@ -23,6 +23,9 @@ if [ "$(ls -A "$RAPIDS_ARTIFACTS_DIR")" ]; then
     upload_name=$(basename "${art_file}")
     pkg_name="${pkg_prefix}.${upload_name}"
     rapids-upload-to-s3 "${pkg_name}" "${art_file}"
+    if [ -d telemetry-artifacts ]; then
+      ls -l "${art_file}" >> telemetry-artifacts/artifact-list.txt
+    fi
   done
 else
   echo "No additional artifacts found."

--- a/tools/rapids-upload-to-anaconda
+++ b/tools/rapids-upload-to-anaconda
@@ -64,5 +64,10 @@ for OBJ in $(jq -nr 'env.CONDA_ARTIFACTS | fromjson | .[]'); do
     --no-progress \
     ${PKGS_TO_UPLOAD}
 
+  if [ -d telemetry-artifacts ]; then
+    ls -l "${UNTAR_DEST}"/*.tar.bz2 >> telemetry-artifacts/artifact-list.txt
+    ls -l "${UNTAR_DEST}"/*.conda >> telemetry-artifacts/artifact-list.txt
+  fi
+
   echo ""
 done

--- a/tools/rapids-wheels-anaconda
+++ b/tools/rapids-wheels-anaconda
@@ -73,3 +73,7 @@ rapids-retry anaconda \
     --no-progress \
     "${WHEEL_DIR}"/*.whl
 echo ""
+
+if [ -d telemetry-artifacts ]; then
+  ls -l "${WHEEL_DIR}"/*.whl >> telemetry-artifacts/artifact-list.txt
+fi


### PR DESCRIPTION
The idea is to capture the package sizes with each build. It would be nicer to get sizes for individual files (.so's) in packages, but this is a decent start.