### PR TITLE
Add `rapids-rattler-channel-string` tool

### DIFF
--- a/tools/rapids-rattler-channel-string
+++ b/tools/rapids-rattler-channel-string
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+RAPIDS_CHANNEL="rapidsai-nightly"
+DASK_CHANNEL="dask/label/dev"
+
+# Replace dev/nightly channels if build is a release build
+if rapids-is-release-build; then
+  RAPIDS_CHANNEL="rapidsai"
+  DASK_CHANNEL=""
+fi
+
+channels=("$RAPIDS_CHANNEL" "$DASK_CHANNEL" "conda-forge" "nvidia")
+
+_add_c_prefix() {
+  for channel in "${channels[@]}"; do
+    # Only echo out a channel if it is non-empty
+    if [[ $channel ]]; then
+      echo -n "-c $channel "
+    fi
+  done
+}
+
+echo "Using channels: ${channels[*]}"
+
+CHANNELS=$(_add_c_prefix)
+export CHANNELS

--- a/tools/rapids-rattler-channel-string
+++ b/tools/rapids-rattler-channel-string
@@ -22,5 +22,5 @@ _add_c_prefix() {
 
 rapids-logger "Using channels: ${channels[*]}"
 
-CHANNELS=$(_add_c_prefix)
-export CHANNELS
+RATTLER_CHANNELS=$(_add_c_prefix)
+export RATTLER_CHANNELS

--- a/tools/rapids-rattler-channel-string
+++ b/tools/rapids-rattler-channel-string
@@ -20,7 +20,7 @@ _add_c_prefix() {
   done
 }
 
-echo "Using channels: ${channels[*]}"
+rapids-logger "Using channels: ${channels[*]}"
 
 CHANNELS=$(_add_c_prefix)
 export CHANNELS


### PR DESCRIPTION
This is designed to be `source`d so that the channel list can be
`echo`ed to stdout while saving the properly formatted channel string in
an exported variable.

xref rapidsai/rmm#1796