### PR TITLE
refactor(rattler): only include `nvidia` channel for CUDA11 builds

### DIFF
--- a/tools/rapids-rattler-channel-string
+++ b/tools/rapids-rattler-channel-string
@@ -2,7 +2,7 @@
 
 RAPIDS_CHANNEL="rapidsai-nightly"
 DASK_CHANNEL="dask/label/dev"
-NVIDIA_CHANNEL="nvidia"
+NVIDIA_CHANNEL=""
 
 # Replace dev/nightly channels if build is a release build
 if rapids-is-release-build; then
@@ -12,8 +12,8 @@ fi
 
 # Only include nvidia channel if we're on cuda11
 IFS='.' read -ra CUDA_VERSION_ARRAY <<< "$RAPIDS_CUDA_VERSION"
-if [ "${CUDA_VERSION_ARRAY[0]}" -eq "12" ]; then
-  NVIDIA_CHANNEL=""
+if [ "${CUDA_VERSION_ARRAY[0]}" -eq "11" ]; then
+  NVIDIA_CHANNEL="nvidia"
 fi
 
 channels=("$RAPIDS_CHANNEL" "$DASK_CHANNEL" "conda-forge" "$NVIDIA_CHANNEL")

--- a/tools/rapids-rattler-channel-string
+++ b/tools/rapids-rattler-channel-string
@@ -2,6 +2,7 @@
 
 RAPIDS_CHANNEL="rapidsai-nightly"
 DASK_CHANNEL="dask/label/dev"
+NVIDIA_CHANNEL="nvidia"
 
 # Replace dev/nightly channels if build is a release build
 if rapids-is-release-build; then
@@ -9,13 +10,19 @@ if rapids-is-release-build; then
   DASK_CHANNEL=""
 fi
 
-channels=("$RAPIDS_CHANNEL" "$DASK_CHANNEL" "conda-forge" "nvidia")
+# Only include nvidia channel if we're on cuda11
+IFS='.' read -ra CUDA_VERSION_ARRAY <<< "$RAPIDS_CUDA_VERSION"
+if [ "${CUDA_VERSION_ARRAY[0]}" -eq "12" ]; then
+  NVIDIA_CHANNEL=""
+fi
+
+channels=("$RAPIDS_CHANNEL" "$DASK_CHANNEL" "conda-forge" "$NVIDIA_CHANNEL")
 
 _add_c_prefix() {
   for channel in "${channels[@]}"; do
     # Only echo out a channel if it is non-empty
     if [[ $channel ]]; then
-      echo -n "-c $channel "
+      echo -n "--channel $channel "
     fi
   done
 }


### PR DESCRIPTION
We don't need the `nvidia` channel for CUDA12 and it can complicate solves, so we only include it for CUDA11.

xref rapidsai/build-planning#47

