### PR TITLE
rapids-conda-retry: retry on 'failed writing received data to disk'

### DIFF
--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -118,6 +118,9 @@ function runConda {
         elif grep -q "Error when extracting package:" "${outfile}"; then
             retryingMsg="Retrying, found 'Error when extracting package:' in output..."
             needToRetry=1
+        elif grep -q -i "Failed writing received data to disk" "${outfile}"; then
+            retryingMsg="Retrying, found 'Failed writing received data to disk' in output..."
+            needToRetry=1
         elif grep -q "File not valid: SHA256 sum doesn't match expectation" "${outfile}"; then
             retryingMsg="Retrying, found 'File not valid: SHA256 sum doesn't match expectation' in output..."
             needToRetry=1
@@ -159,6 +162,7 @@ function runConda {
 'DependencyNeedsBuildingError:', \
 'EOFError:', \
 'Error when extracting package:', \
+'Failed writing received data to disk', \
 'File not valid: SHA256 sum doesn't match expectation', \
 'JSONDecodeError:', \
 'Multi-download failed', \


### PR DESCRIPTION
Over the last week, I've observed a `conda`-based CI jobs sometimes failing with errors like this:

> error    libmamba ZSTD decompression error: Unknown frame descriptor
> ...
> RuntimeError: Download error (23) Failed writing received data to disk/application [https://conda.anaconda.org/legate/label/rc/noarch/repodata.json.zst]
> Failure writing output to destination, passed 632 returned 633

<details><summary>full traceback (click me)</summary>

```text
Attempting to finalize metadata for legate-raft
error    libmamba ZSTD decompression error: Unknown frame descriptor
Traceback (most recent call last):
  File "/opt/conda/bin/conda-mambabuild", line 10, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.10/site-packages/boa/cli/mambabuild.py", line 301, in main
    call_conda_build(action, config)
  File "/opt/conda/lib/python3.10/site-packages/boa/cli/mambabuild.py", line 273, in call_conda_build
    result = api.build(
  File "/opt/conda/lib/python3.10/site-packages/conda_build/api.py", line 250, in build
    return build_tree(
  File "/opt/conda/lib/python3.10/site-packages/conda_build/build.py", line 3638, in build_tree
    packages_from_this = build(
  File "/opt/conda/lib/python3.10/site-packages/conda_build/build.py", line 2308, in build
    output_metas = expand_outputs([(m, need_source_download, need_reparse_in_env)])
  File "/opt/conda/lib/python3.10/site-packages/conda_build/render.py", line 916, in expand_outputs
    for output_dict, m in deepcopy(_m).get_output_metadata_set(
  File "/opt/conda/lib/python3.10/site-packages/conda_build/metadata.py", line 2737, in get_output_metadata_set
    conda_packages = finalize_outputs_pass(
  File "/opt/conda/lib/python3.10/site-packages/conda_build/metadata.py", line 1090, in finalize_outputs_pass
    parent_metadata.parse_until_resolved()
  File "/opt/conda/lib/python3.10/site-packages/conda_build/metadata.py", line 1443, in parse_until_resolved
    self.parse_again(
  File "/opt/conda/lib/python3.10/site-packages/conda_build/metadata.py", line 1343, in parse_again
    self._get_contents(
  File "/opt/conda/lib/python3.10/site-packages/conda_build/metadata.py", line 2089, in _get_contents
    rendered = template.render(environment=env)
  File "/opt/conda/lib/python3.10/site-packages/jinja2/environment.py", line 1295, in render
    self.environment.handle_exception()
  File "/opt/conda/lib/python3.10/site-packages/jinja2/environment.py", line 942, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/__w/legate-raft/legate-raft/conda/recipes/legate-raft/meta.yaml", line 72, in top-level template code
    # cuda-version is used to constrain __cuda
  File "/opt/conda/lib/python3.10/site-packages/conda_build/jinja_context.py", line 305, in pin_compatible
    pins, _, _ = get_env_dependencies(m, "host", m.config.variant)
  File "/opt/conda/lib/python3.10/site-packages/conda_build/render.py", line 156, in get_env_dependencies
    precs = environ.get_package_records(
  File "/opt/conda/lib/python3.10/site-packages/boa/cli/mambabuild.py", line 124, in mamba_get_package_records
    solver = _get_solver(channel_urls, subdir, output_folder)
  File "/opt/conda/lib/python3.10/site-packages/boa/cli/mambabuild.py", line 102, in _get_solver
    solver = MambaSolver(channel_urls, subdir, output_folder)
  File "/opt/conda/lib/python3.10/site-packages/boa/core/solver.py", line 128, in __init__
    self.index = load_channels(
  File "/opt/conda/lib/python3.10/site-packages/boa/core/utils.py", line 249, in load_channels
    index = get_index(
  File "/opt/conda/lib/python3.10/site-packages/boa/core/utils.py", line 230, in get_index
    is_downloaded = dlist.download(api.MAMBA_DOWNLOAD_FAILFAST)
RuntimeError: Download error (23) Failed writing received data to disk/application [https://conda.anaconda.org/legate/label/rc/noarch/repodata.json.zst]
Failure writing output to destination, passed 632 returned 633
[rapids-conda-retry] conda returned exit code: 1
[rapids-conda-retry] Exiting, no retryable conda errors detected: 'ChecksumMismatchError:', 'ChunkedEncodingError:', 'CondaHTTPError:', 'CondaMultiError:', 'CondaSSLError:', 'Connection broken:', 'ConnectionError:', 'DependencyNeedsBuildingError:', 'EOFError:', 'Error when extracting package:', 'File not valid: SHA256 sum doesn't match expectation', 'JSONDecodeError:', 'Multi-download failed', 'Response ended prematurely', 'Timeout was reached', 'Unexpected error [0-9]+ on netlink descriptor [0-9]+', segfault exit code 139
```

</details>

([example build link](https://github.com/rapidsai/legate-raft/actions/runs/13501915952/job/37722231292?pr=14#step:5:434))

In every case, I've seen that succeed on a retry.

This proposes adding such cases to the list of retryable errors in `rapids-conda-retry`.