### PR TITLE
add mkdir -p for telemetry-artifacts

### DIFF
--- a/tools/rapids-telemetry-setup
+++ b/tools/rapids-telemetry-setup
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Set up the environment for telemetry. This is mostly done in CI scripts,
+# but some stuff is done here to allow the data capture to work (and not raise errors) locally.
+
+mkdir -p telemetry-artifacts

--- a/tools/rapids-telemetry-setup
+++ b/tools/rapids-telemetry-setup
@@ -2,4 +2,4 @@
 # Set up the environment for telemetry. This is mostly done in CI scripts,
 # but some stuff is done here to allow the data capture to work (and not raise errors) locally.
 
-mkdir -p telemetry-artifacts
+mkdir -p ${GITHUB_WORKSPACE:-"."}/telemetry-artifacts

--- a/tools/rapids-telemetry-setup
+++ b/tools/rapids-telemetry-setup
@@ -2,4 +2,4 @@
 # Set up the environment for telemetry. This is mostly done in CI scripts,
 # but some stuff is done here to allow the data capture to work (and not raise errors) locally.
 
-mkdir -p ${GITHUB_WORKSPACE:-"."}/telemetry-artifacts
+mkdir -p "${GITHUB_WORKSPACE:-"."}"/telemetry-artifacts


### PR DESCRIPTION
The build scripts encountered issues when carrying out build workflows (as opposed to PR workflows) because build workflows do not yet have the telemetry boilerplate. One element of this boilerplate is creation of a folder that build scripts can place content into. That content will be available when telemetry is being parsed.

This PR adds an abstraction layer of sorts, so that we can make changes to telemetry setup without requiring changes to every repo. This script should be run (or sourced?) by the ci/build_XYZ.sh scripts in each project.