### PR TITLE
Add rapids-telemetry-record

### DIFF
--- a/tools/rapids-telemetry-record
+++ b/tools/rapids-telemetry-record
@@ -14,7 +14,7 @@ output_path="${GITHUB_WORKSPACE:-"."}/telemetry-artifacts/${output_file}"
 
 # Run the command, redirecting both stdout and stderr to tee.
 # This writes the combined output to the specified file while also printing it.
-"$@" 2>&1 | tee "$output_file"
+"$@" 2>&1 | tee "${output_path}"
 
 # Exit with the same status as the command that was run.
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tools/rapids-telemetry-record
+++ b/tools/rapids-telemetry-record
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Check for at least 2 arguments: filename and command
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 filename command [arguments...]"
+    exit 1
+fi
+
+output_file="$1"
+shift
+
+# TODO: Make this a temporary path rather than writing in the GITHUB_WORKSPACE.
+output_path="${GITHUB_WORKSPACE:-"."}/telemetry-artifacts/${output_file}"
+
+# Run the command, redirecting both stdout and stderr to tee.
+# This writes the combined output to the specified file while also printing it.
+"$@" 2>&1 | tee "$output_file"
+
+# Exit with the same status as the command that was run.
+exit ${PIPESTATUS[0]}


### PR DESCRIPTION
This PR proposes a design for `rapids-telemetry-record` so that RAPIDS repositories do not need to hardcode a path for telemetry log artifact output.
