### PR TITLE
Update comment to reference conda-build

### DIFF
--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -218,7 +218,7 @@ elif grep -q -E 'install|env.*create|env.*update' <<< "${args}"; then
     # 'conda install', 'conda env create', 'conda env update' should never run for more than 45 minutes
     timeout_duration='45m'
 else
-    # other commands falling here might include 'conda mambabuild' or similar,
+    # other commands falling here might include 'conda build' or similar,
     # which could take several hours for expensive-to-build projects
     timeout_duration='6h'
 fi


### PR DESCRIPTION
As `conda-mambabuild` is going away, update this reference to `conda-build`.

xref: https://github.com/rapidsai/build-planning/issues/149