### PR TITLE
feat(rattler): add common rattler args to sourceable array variable

### DIFF
--- a/tools/rapids-rattler-channel-string
+++ b/tools/rapids-rattler-channel-string
@@ -31,3 +31,10 @@ rapids-logger "Using channels: ${channels[*]}"
 
 IFS=" " read -r -a RATTLER_CHANNELS <<< "$(_add_c_prefix)"
 export RATTLER_CHANNELS
+
+# Set default CLI args passed to `rattler-build`
+RATTLER_ARGS=("--experimental" "--no-build-id" "--output-dir $RAPIDS_CONDA_BLD_OUTPUT_DIR")
+
+rapids-logger "Using rattler-build args: ${RATTLER_ARGS[*]}"
+
+export RATTLER_ARGS


### PR DESCRIPTION
Resolves rapidsai/build-planning#156

We pass the same 3 args to every invocation of `rattler-build`, so we can
centralize those in an array variable and then splat them into place