### PR TITLE
refactor(conda): remove `rapidsai` channel for non-release builds

### DIFF
--- a/tools/rapids-configure-conda-channels
+++ b/tools/rapids-configure-conda-channels
@@ -20,6 +20,11 @@ remove_conda_channel() {
   fi
 }
 
+# Remove release channel if build is not a release build
+if ! rapids-is-release-build; then
+  remove_conda_channel 'rapidsai'
+fi
+
 # Remove nightly channels if build is a release build
 if rapids-is-release-build; then
   remove_conda_channel 'rapidsai-nightly'


### PR DESCRIPTION
We should have clean separation between `rapidsai` and `rapidsai-nightly`.

Probably should hold off on merging this until the 25.04 release is finished, though, just in case this breaks something.
