### PR TITLE
retry conda operations on 'file size doesnt match'

### DIFF
--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -121,6 +121,9 @@ function runConda {
         elif grep -q -i "Failed writing received data to disk" "${outfile}"; then
             retryingMsg="Retrying, found 'Failed writing received data to disk' in output..."
             needToRetry=1
+        elif grep -q "File not valid: file size doesn't match expectation" "${outfile}"; then
+            retryingMsg="Retrying, found 'File not valid: file size doesn't match expectation' in output..."
+            needToRetry=1
         elif grep -q "File not valid: SHA256 sum doesn't match expectation" "${outfile}"; then
             retryingMsg="Retrying, found 'File not valid: SHA256 sum doesn't match expectation' in output..."
             needToRetry=1
@@ -163,6 +166,7 @@ function runConda {
 'EOFError:', \
 'Error when extracting package:', \
 'Failed writing received data to disk', \
+'File not valid: file size doesn't match expectation', \
 'File not valid: SHA256 sum doesn't match expectation', \
 'JSONDecodeError:', \
 'Multi-download failed', \


### PR DESCRIPTION
Over on https://github.com/rapidsai/docker/pull/670, I just observed a couple of `conda install` operations fail like this:

```text
Confirm changes: [Y/n] 
Transaction starting
error    libmamba File not valid: file size doesn't match expectation "/opt/conda/pkgs/libcugraph-25.06.00a20-cuda12_250326_g1a0da4b25_20.conda"
    Expected: 937900582
    Actual: 726812060
    
libcugraph-25.06.00a20-cuda12_250326_g1a0da4b25_20.conda tarball has incorrect size
critical libmamba Found incorrect downloads. Aborting
```

([build link](https://github.com/rapidsai/docker/actions/runs/14085615168/job/39448853253?pr=670#step:10:911))

I think this is a retryable error... I think what really happened here is that the download was interrupted due to some temporary network issue, which caused `libmamba` to report that it had downloaded less data than it expected to.

That's consistent with the fact that all the instances of this error that I observed were for very large files like `libcugraph` and `libcuvs`.

This PR proposes retrying stuff like that.