### PR TITLE
refactor(rattler): remove `dask/label/dev` from default rattler channels

### DIFF
--- a/tools/rapids-rattler-channel-string
+++ b/tools/rapids-rattler-channel-string
@@ -1,13 +1,11 @@
 #!/bin/bash
 
 RAPIDS_CHANNEL="rapidsai-nightly"
-DASK_CHANNEL="dask/label/dev"
 NVIDIA_CHANNEL=""
 
 # Replace dev/nightly channels if build is a release build
 if rapids-is-release-build; then
   RAPIDS_CHANNEL="rapidsai"
-  DASK_CHANNEL=""
 fi
 
 CHANNEL_PRIORITY="strict"
@@ -21,7 +19,7 @@ if [ "${CUDA_VERSION_ARRAY[0]}" -eq "11" ]; then
   CHANNEL_PRIORITY="disabled"
 fi
 
-channels=("$RAPIDS_CHANNEL" "$DASK_CHANNEL" "conda-forge" "$NVIDIA_CHANNEL")
+channels=("$RAPIDS_CHANNEL" "conda-forge" "$NVIDIA_CHANNEL")
 
 _add_c_prefix() {
   for channel in "${channels[@]}"; do


### PR DESCRIPTION
Since `rapids-dask-dependency` now points at stable releases of `dask`, and because including `dask/label/dev` breaks strict channel priority in our CI builds, I'm removing it here.

If any projects DO still require it, we can add it back on a per-project basis, but it is more harm than help as a default here.
