### PR TITLE
Pipefail telemetry scripts

### DIFF
--- a/tools/rapids-telemetry-record
+++ b/tools/rapids-telemetry-record
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -exo pipefail
 
 # Check for at least 2 arguments: filename and command
 if [ "$#" -lt 2 ]; then

--- a/tools/rapids-telemetry-record
+++ b/tools/rapids-telemetry-record
@@ -10,12 +10,18 @@ fi
 output_file="$1"
 shift
 
-# TODO: Make this a temporary path rather than writing in the GITHUB_WORKSPACE.
-output_path="${GITHUB_WORKSPACE:-"."}/telemetry-artifacts/${output_file}"
+if [ ! -d "${GITHUB_WORKSPACE:-"."}/telemetry-artifacts" ]; then
+    echo "Telemetry artifacts directory does not exist. Please run rapids-telemetry-setup first."
+    echo "Skipping telemetry recording."
+    # TODO: Make this a temporary path rather than writing in the GITHUB_WORKSPACE.
+    output_path="${GITHUB_WORKSPACE:-"."}/telemetry-artifacts/${output_file}"
 
-# Run the command, redirecting both stdout and stderr to tee.
-# This writes the combined output to the specified file while also printing it.
-"$@" 2>&1 | tee "${output_path}"
+    # Run the command, redirecting both stdout and stderr to tee.
+    # This writes the combined output to the specified file while also printing it.
+    "$@" 2>&1 | tee "${output_path}"
+else
+    "$@" 2>&1
+fi
 
 # Exit with the same status as the command that was run.
 exit "${PIPESTATUS[0]}"

--- a/tools/rapids-telemetry-setup
+++ b/tools/rapids-telemetry-setup
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Set up the environment for telemetry. This is mostly done in CI scripts,
 # but some stuff is done here to allow the data capture to work (and not raise errors) locally.
+set -exo pipefail
 
 mkdir -p "${GITHUB_WORKSPACE:-"."}"/telemetry-artifacts


### PR DESCRIPTION
@bdice and @gforsyth encountered a very obtuse error in building RMM: https://github.com/rapidsai/rmm/actions/runs/14456467636/job/40596452557?pr=1883#annotation:9:2333)

```
rmm install time:
real	0m13.430s
user	0m8.494s
sys	0m1.192s

Error: Dev container exec failed: (exit code: 1)
```

The error was happening here: https://github.com/rapidsai/rmm/actions/runs/14456467636/job/40596452557?pr=1883#step:9:765

```
tee: telemetry-artifacts/build.log: No such file or directory
```

Setting these bash options will make pipelines error out, but we also explicit handle the absence of this folder as a sign that the command output should not be captured to the telemetry folder.