### PR TITLE
Use array splitting to preserve quoting for *unquoted* arguments this time.

### DIFF
--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -218,7 +218,7 @@ done
 if [ -n "${RAPIDS_CONDA_RETRY_TIMEOUT:-}" ]; then
     # allow timeout to be set by an environment variable
     timeout_duration=${RAPIDS_CONDA_RETRY_TIMEOUT}
-elif grep -q -E 'install|env.*create|env.*update' <<< "${args}"; then
+elif grep -q -E 'install|env.*create|env.*update' <<< "${args[@]}"; then
     # 'conda install', 'conda env create', 'conda env update' should never run for more than 45 minutes
     timeout_duration='45m'
 else

--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -60,7 +60,6 @@ sleep_interval=${RAPIDS_CONDA_RETRY_SLEEP:=10}
 exitcode=0
 needToRetry=0
 retries=0
-args=""
 
 # Temporarily set this to something else (eg. a script called "testConda" that
 # prints "CondaHTTPError:" and exits with 1) for testing this script.
@@ -77,7 +76,7 @@ condaCmd=${RAPIDS_CONDA_EXE:=conda}
 #    needToRetry: 1 if the command should be retried, 0 if it should not be
 function runConda {
     # shellcheck disable=SC2086
-    timeout --verbose "${timeout_duration}" "${condaCmd}" "${args}" 2>&1| tee "${outfile}"
+    timeout --verbose "${timeout_duration}" "${condaCmd}" "$@" 2>&1| tee "${outfile}"
     exitcode=$?
     needToRetry=0
     needToClean=0
@@ -192,6 +191,7 @@ segfault exit code 139"
 fi
 }
 
+args=()
 # Process and remove args recognized only by this script, save others for conda
 # Process help separately
 for arg in "$@"; do
@@ -206,7 +206,7 @@ for arg in "$@"; do
    elif [[ ${opt} == "--condaretry_sleep_interval" ]]; then
       sleep_interval=${val}
    else
-      args="${args} ${arg}"
+      args+=("${arg}")
    fi
 done
 
@@ -231,7 +231,7 @@ rapids-echo-stderr "timeout for conda operations: '${timeout_duration}'"
 # Run command
 outfile=$(mktemp)
 # shellcheck disable=SC2086
-runConda "${args}"
+runConda "${args[@]}"
 
 # Retry loop, only if needed
 while (( needToRetry == 1 )) && \
@@ -243,7 +243,7 @@ while (( needToRetry == 1 )) && \
    rapids-echo-stderr "Starting, retry ${retries} of ${max_retries} -> sleep done..."
 
    # shellcheck disable=SC2086
-   runConda "${args}"
+   runConda "${args[@]}"
 done
 
 rm -f "${outfile}"

--- a/tools/rapids-pip-retry
+++ b/tools/rapids-pip-retry
@@ -45,7 +45,6 @@ sleep_interval=${RAPIDS_PIP_RETRY_SLEEP:=10}
 exitcode=0
 needToRetry=0
 retries=0
-args=""
 
 # Temporarily set this to something else (eg. a script called "testPip" that
 # prints "ERROR: THESE PACKAGES DO NOT MATCH THE HASHES" and exits with 1) for
@@ -63,7 +62,7 @@ pipCmd=${RAPIDS_PIP_EXE:=python -m pip}
 #    needToRetry: 1 if the command should be retried, 0 if it should not be
 function runPip {
     # shellcheck disable=SC2086
-    ${pipCmd} "${args}" 2>&1  | tee "${outfile}"
+    ${pipCmd} "$@" 2>&1  | tee "${outfile}"
     exitcode=$?
     needToRetry=0
     needToClean=0
@@ -98,6 +97,7 @@ THESE PACKAGES DO NOT MATCH THE HASHES"
 fi
 }
 
+args=()
 # Process and remove args recognized only by this script, save others for pip
 # Process help separately
 for arg in "$@"; do
@@ -112,14 +112,14 @@ for arg in "$@"; do
    elif [[ ${opt} == "--pipretry_sleep_interval" ]]; then
       sleep_interval=${val}
    else
-      args="${args} ${arg}"
+      args+=("${arg}")
    fi
 done
 
 # Run command
 outfile=$(mktemp)
 # shellcheck disable=SC2086
-runPip "${args}"
+runPip "${args[@]}"
 
 # Retry loop, only if needed
 while (( needToRetry == 1 )) && \
@@ -131,7 +131,7 @@ while (( needToRetry == 1 )) && \
    rapids-echo-stderr "Starting, retry ${retries} of ${max_retries} -> sleep done..."
 
    # shellcheck disable=SC2086
-   runPip "${args}"
+   runPip "${args[@]}"
 done
 
 rm -f "${outfile}"


### PR DESCRIPTION
Re-fix https://github.com/rapidsai/gha-tools/pull/160

This fixes issues like
```bash
+ rapids-mamba-retry uninstall -q -y -n legate numpy
...
usage: mamba [-h] [-v] [--no-plugins] [-V] COMMAND ...
mamba: error: argument COMMAND: invalid choice: ' uninstall -q -y -n legate numpy' (choose from activate, clean, commands, compare, config, ...)
```