### PR TITLE
Add rapids-retry to gh commands

### DIFF
--- a/tools/rapids-download-from-github
+++ b/tools/rapids-download-from-github
@@ -16,6 +16,6 @@ pkg_name="$1"
 unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 
 rapids-echo-stderr "Downloading and decompressing ${pkg_name} from Run ID ${github_run_id} into ${unzip_dest}"
-gh run download "${github_run_id}" --repo "${RAPIDS_REPOSITORY}" --name "${pkg_name}" --dir "${unzip_dest}" 
+rapids-retry gh run download "${github_run_id}" --repo "${RAPIDS_REPOSITORY}" --name "${pkg_name}" --dir "${unzip_dest}" 
 
 echo -n "${unzip_dest}"

--- a/tools/rapids-get-pr-conda-artifact-github
+++ b/tools/rapids-get-pr-conda-artifact-github
@@ -23,7 +23,7 @@ commit="${4:-}"
 
 # If commit is not provided, get the latest commit on the PR
 if [[ -z "${commit}" ]]; then
-    commit=$(gh pr view "${pr}" --repo rapidsai/"${repo}" --json headRefOid --jq '.headRefOid[0:7]')
+    commit=$(rapids-retry gh pr view "${pr}" --repo rapidsai/"${repo}" --json headRefOid --jq '.headRefOid')
 fi
 
 # Use a subshell to isolate environment variable changes

--- a/tools/rapids-get-pr-wheel-artifact-github
+++ b/tools/rapids-get-pr-wheel-artifact-github
@@ -29,7 +29,7 @@ fi
 
 # If commit is not provided, get the latest commit on the PR
 if [[ -z "${commit}" ]]; then
-    commit=$(gh pr view "${pr}" --repo rapidsai/"${repo}" --json headRefOid --jq '.headRefOid[0:7]')
+    commit=$(rapids-retry gh pr view "${pr}" --repo rapidsai/"${repo}" --json headRefOid --jq '.headRefOid')
 fi
 
 # Use a subshell to isolate environment variable changes

--- a/tools/rapids-github-run-id
+++ b/tools/rapids-github-run-id
@@ -7,8 +7,11 @@ export RAPIDS_SCRIPT_NAME="rapids-github-run-id"
 
 # While called by CI, all the environment variables are set by the caller. However when run locally, these environment variables are set by rapids-prompt-local-repo-config
 case "${RAPIDS_BUILD_TYPE}" in
-  pull-request|branch|nightly)
-    run_id=$(gh run list --repo "${RAPIDS_REPOSITORY}" --branch "${RAPIDS_REF_NAME}" --commit "${RAPIDS_SHA}" --json databaseId --jq '.[0] | .databaseId')
+  pull-request|branch)
+    run_id=${GITHUB_RUN_ID}
+    ;;
+  nightly)
+    run_id=$(rapids-retry gh run list --repo "${RAPIDS_REPOSITORY}" --branch "${RAPIDS_REF_NAME}" --commit "${RAPIDS_SHA}" --workflow "${RAPIDS_BUILD_WORKFLOW_NAME:-build.yaml}" --json databaseId --jq '.[0] | .databaseId')
     ;;
   *)
     rapids-echo-stderr "please pass a valid RAPIDS_BUILD_TYPE"

--- a/tools/rapids-upload-to-anaconda-github
+++ b/tools/rapids-upload-to-anaconda-github
@@ -19,7 +19,7 @@ github_run_id="$(rapids-github-run-id)"
 unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 
 #Download all artifacts with conda in the name to unzip_dest
-gh run download "${github_run_id}" --repo "${RAPIDS_REPOSITORY}" --dir "${unzip_dest}" --pattern "*conda*"
+rapids-retry gh run download "${github_run_id}" --repo "${RAPIDS_REPOSITORY}" --dir "${unzip_dest}" --pattern "*conda*"
 
 # Find all directories within unzip_dest
 for artifact_dir in "${unzip_dest}"/*/; do

--- a/tools/rapids-wheels-anaconda-github
+++ b/tools/rapids-wheels-anaconda-github
@@ -43,7 +43,7 @@ unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 rapids-echo-stderr "Downloading ${PKG_TYPE}_${WHEEL_NAME} wheels to ${unzip_dest}"
 
 #Download all artifacts with WHEEL_SEARCH_KEY in the name to unzip_dest
-gh run download "${github_run_id}" --repo "${RAPIDS_REPOSITORY}" --dir "${unzip_dest}" --pattern "*${WHEEL_SEARCH_KEY}*"
+rapids-retry gh run download "${github_run_id}" --repo "${RAPIDS_REPOSITORY}" --dir "${unzip_dest}" --pattern "*${WHEEL_SEARCH_KEY}*"
 
 find "${unzip_dest}" -name "*.whl" -exec cp {} "${WHEEL_DIR}/" \;
 


### PR DESCRIPTION
This PR addresses nightly CI test fails due to wrong Github actions run name being picked up, and also add the `rapids-retry` function to any `gh` cli calls to avoid failures due to network inconsistencies.