### PR TITLE
rapids-pip-retry: retry on 'incomplete-download' error

### DIFF
--- a/tools/rapids-pip-retry
+++ b/tools/rapids-pip-retry
@@ -72,7 +72,7 @@ function runPip {
         # Show exit code
         rapids-echo-stderr "pip returned exit code: ${exitcode}"
 
-        if grep -q -E 'error.*incomplete-download' "${outfile}"; then
+        if grep -q -E 'error.*incomplete\-download' "${outfile}"; then
             retryingMsg="Retrying, found 'error: incomplete-download' in output..."
             needToRetry=1
         elif grep -q 'THESE PACKAGES DO NOT MATCH THE HASHES' "${outfile}"; then

--- a/tools/rapids-pip-retry
+++ b/tools/rapids-pip-retry
@@ -72,12 +72,15 @@ function runPip {
         # Show exit code
         rapids-echo-stderr "pip returned exit code: ${exitcode}"
 
-
-        if grep -q 'THESE PACKAGES DO NOT MATCH THE HASHES' "${outfile}"; then
+        if grep -q -E 'error.*incomplete-download' "${outfile}"; then
+            retryingMsg="Retrying, found 'error: incomplete-download' in output..."
+            needToRetry=1
+        elif grep -q 'THESE PACKAGES DO NOT MATCH THE HASHES' "${outfile}"; then
             retryingMsg="Retrying, found Hash Mismatch Error in output..."
             needToRetry=1
         else
             rapids-echo-stderr "Exiting, no retryable ${RAPIDS_PIP_EXE} errors detected: \
+error: incomplete-download, \
 THESE PACKAGES DO NOT MATCH THE HASHES"
         fi
 


### PR DESCRIPTION
Over on https://github.com/rapidsai/cuvs/pull/805, I just observed an error in a `pip install` that looks like it might be a similar root cause to #132.

```text
Collecting nvidia-cublas-cu11 (from libcuvs-cu11==25.6.*,>=0.0.0a0)
  Downloading https://pypi.nvidia.com/nvidia-cublas-cu11/nvidia_cublas_cu11-11.11.3.6-py3-none-manylinux2014_x86_64.whl (417.9 MB)
      ━━━━━━━━━━━━━━━━━━━━━━━━               268.4/417.9 MB 75.5 MB/s eta 0:00:02
error: incomplete-download

× Download failed because not enough bytes were received (268.4 MB/417.9 MB)
╰─> URL: https://pypi.nvidia.com/nvidia-cublas-cu11/nvidia_cublas_cu11-11.11.3.6-py3-none-manylinux2014_x86_64.whl#sha256=60252822adea5d0b10cd990a7dc7bedf7435f30ae40083c7a624a85a43225abc
```

([build link](https://github.com/rapidsai/cuvs/actions/runs/14768639301/job/41465252975?pr=805))

That type of thing could absolutely be caused by a temporary network interruption or temporary failure in `pypi.nvidia.com`, and so I think it's retryable.

This proposes retrying it in `rapids-pip-retry`.