### PR TITLE
Fix rapids-get-pr-wheel-artifact-github to fetch from GitHub Artifacts

### DIFF
--- a/tools/rapids-get-pr-wheel-artifact-github
+++ b/tools/rapids-get-pr-wheel-artifact-github
@@ -16,4 +16,4 @@
 set -euo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-get-pr-wheel-artifact-github"
 
-_rapids-get-pr-artifact "${1}" "${2}" "${3}" wheel "${4:-}"
+_rapids-get-pr-artifact-github "${1}" "${2}" "${3}" wheel "${4:-}"


### PR DESCRIPTION
Currently `rapids-get-pr-wheel-artifact-github` is not downloading from GitHub Artifacts. This fixes that bug.
