### PR TITLE
WIP: update Github Authentication flow

### DIFF
--- a/tools/rapids-get-pr-conda-artifact-github
+++ b/tools/rapids-get-pr-conda-artifact-github
@@ -16,4 +16,6 @@
 set -euo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-get-pr-conda-artifact-github"
 
+source rapids-prompt-local-github-auth
+
 _rapids-get-pr-artifact-github "${1}" "${2}" "${3}" conda "${4:-}"

--- a/tools/rapids-get-pr-wheel-artifact-github
+++ b/tools/rapids-get-pr-wheel-artifact-github
@@ -16,4 +16,6 @@
 set -euo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-get-pr-wheel-artifact-github"
 
+source rapids-prompt-local-github-auth
+
 _rapids-get-pr-artifact "${1}" "${2}" "${3}" wheel "${4:-}"

--- a/tools/rapids-prompt-local-github-auth
+++ b/tools/rapids-prompt-local-github-auth
@@ -2,8 +2,24 @@
 # A utility script that prompts user to authenticate with GitHub in
 # local environments
 
-if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
-  rapids-echo-stderr "No GitHub token detected in environment"
-  rapids-echo-stderr "Please authenticate with GitHub to continue"
-  gh auth login --web --git-protocol https
+#!/bin/bash
+# A utility script that prompts user to authenticate with GitHub in
+# local environments
+
+declare -a scopes=("repo" "workflow")
+
+# shellcheck disable=SC2068
+if ! gh auth status >/dev/null 2>&1; then
+    rapids-echo-stderr "No GitHub authentication detected"
+    rapids-echo-stderr "Please authenticate with GitHub to continue"
+
+    # Attempt authentication
+    if ! gh auth login \
+        --web --git-protocol https \
+        --hostname "github.com" \
+        ${scopes[@]/#/--scopes }; then
+        
+        rapids-echo-stderr "GitHub authentication failed. Exiting."
+        exit 1
+    fi
 fi

--- a/tools/rapids-upload-to-anaconda-github
+++ b/tools/rapids-upload-to-anaconda-github
@@ -4,6 +4,7 @@
 set -euo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-upload-to-anaconda-github"
 
+source rapids-prompt-local-github-auth
 case "${RAPIDS_BUILD_TYPE}" in
   branch)
     ;&

--- a/tools/rapids-wheels-anaconda-github
+++ b/tools/rapids-wheels-anaconda-github
@@ -14,6 +14,8 @@
 set -eou pipefail
 export RAPIDS_SCRIPT_NAME="rapids-wheels-anaconda-github"
 
+source rapids-prompt-local-github-auth
+
 if [ -z "$1" ]; then
   rapids-echo-stderr "Must specify input arguments: WHEEL_NAME"
   exit 1


### PR DESCRIPTION
This PR is part of the changes to move Build Artifact storage from S3 (`downloads.rapids.ai`) to the Github Artifact Store (see https://github.com/rapidsai/build-infra/issues/237). 

Made changes to the Github Authentication script, which now checks for authentication status rather than a token, and attempts to authenticate over HTTPS protocol if prior authentication is not found. 