### PR TITLE
Make Github Run ID selection stricter, update docs

### DIFF
--- a/tools/rapids-download-conda-from-github
+++ b/tools/rapids-download-conda-from-github
@@ -1,5 +1,5 @@
 #!/bin/bash
-# A utility script that downloads a conda artifact archive from Github Artifacts, unzips it,
+# Downloads a conda artifact archive from Github Artifacts, unzips it,
 # and returns the path to the directory where it was unzipped.
 # Positional Arguments:
 #   1) a string of "cpp" or "python" which determines which conda artifact

--- a/tools/rapids-download-from-github
+++ b/tools/rapids-download-from-github
@@ -1,6 +1,7 @@
 #!/bin/bash
-# A utility script that downloads an artifact from Github Artifacts, unzips it to a temporary directory,
+# Downloads an artifact from Github Artifacts, unzips it to a temporary directory,
 # and prints the location where it was unzipped.
+#
 # Positional Arguments:
 #   1) package name to download from Github Artifacts
 set -euo pipefail

--- a/tools/rapids-download-wheels-from-github
+++ b/tools/rapids-download-wheels-from-github
@@ -1,6 +1,7 @@
 #!/bin/bash
-# A utility script that downloads a wheel artifact archive from Github Artifacts, unzips it,
+# Downloads a wheel artifact archive from Github Artifacts, unzips it,
 # and returns the path to the directory where it was unzipped.
+#
 # Positional Arguments:
 #   1) a string of "cpp" or "python" which determines which wheel artifact
 #      should be downloaded

--- a/tools/rapids-github-run-id
+++ b/tools/rapids-github-run-id
@@ -1,7 +1,22 @@
 #!/bin/bash
-# A utility script that examines environment variables provided
-# by GitHub Actions to print out a Github Workflow Run ID where the expected artifact
-# should be.
+# Determines the GitHub Actions run ID to use in operations with the GitHub API.
+#
+# When environment variable GITHUB_RUN_ID is defined, just returns that value.
+# GITHUB_RUN_ID is set automatically on GitHub Actions.
+# ref: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
+#
+# Otherwise, tries to determine a run ID based on other context in the environment.
+# Most of that is provided by 'rapids-prompt-local-repo-config', see that
+# script's docs for details.
+#
+# Where multiple run IDs match the supplied configuration, the most-recently-created one
+# is chosen.
+#
+# Additional environment variables recognized by 'rapids-github-run-id':
+#
+#   * RAPIDS_BUILD_WORKFLOW_NAME = Filename for the workflow that the run corresponds to.
+#                                  Defaults to 'pr.yaml' for RAPIDS_BUILD_TYPE="pull-request" and 'build.yaml' otherwise).
+#
 set -euo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-github-run-id"
 
@@ -13,8 +28,8 @@ case "${RAPIDS_BUILD_TYPE}" in
       --branch "${RAPIDS_REF_NAME}" \
       --commit "${RAPIDS_SHA}" \
       --workflow "${RAPIDS_BUILD_WORKFLOW_NAME:-pr.yaml}" \
-      --json databaseId \
-      --jq '.[0] | .databaseId')}
+      --json 'createdAt,databaseId' \
+      --jq 'sort_by(.createdAt) | reverse | .[0] | .databaseId')}
     ;;
   branch)
     run_id=${GITHUB_RUN_ID:-$(rapids-retry --quiet gh run list \
@@ -23,22 +38,30 @@ case "${RAPIDS_BUILD_TYPE}" in
       --commit "${RAPIDS_SHA}" \
       --workflow "${RAPIDS_BUILD_WORKFLOW_NAME:-build.yaml}" \
       --event "push" \
-      --json databaseId \
-      --jq '.[0] | .databaseId')}
+      --json 'createdAt,databaseId' \
+      --jq 'sort_by(.createdAt) | reverse | .[0] | .databaseId')}
     ;;
   nightly)
+    # Notice that for nightly runs, this script intentionally does not return GITHUB_RUN_ID.
+    #
+    # In RAPIDS CI, projects often have 2 separate workflows for nightlies:
+    #
+    #   * build.yaml = builds and uploads packages
+    #   * test.yaml  = installs nightly packages and runs tests
+    #
+    # From GitHub's perspective, those are different "runs", with different IDs.
+    # GitHub Actions organizes artifacts by run ID.
     run_id=$(rapids-retry --quiet gh run list \
       --repo "${RAPIDS_REPOSITORY}" \
       --branch "${RAPIDS_REF_NAME}" \
       --commit "${RAPIDS_SHA}" \
       --workflow "${RAPIDS_BUILD_WORKFLOW_NAME:-build.yaml}" \
       --event "workflow_dispatch" \
-      --created "${RAPIDS_NIGHTLY_DATE}" \
-      --json databaseId \
-      --jq '.[0] | .databaseId')
+      --json 'createdAt,databaseId' \
+      --jq 'sort_by(.createdAt) | reverse | .[0] | .databaseId')
     ;;
   *)
-    rapids-echo-stderr "please pass a valid RAPIDS_BUILD_TYPE"
+    rapids-echo-stderr "RAPIDS_BUILD_TYPE must be one of [branch, nightly, pull-request]"
     exit 1
     ;;
 esac

--- a/tools/rapids-github-run-id
+++ b/tools/rapids-github-run-id
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Determines the GitHub Actions run ID to use in operations with the GitHub API.
 #
-# When environment variable GITHUB_RUN_ID is defined, just returns that value.
+# When environment variable GITHUB_RUN_ID is defined, just returns that value (except for on nightly builds... see below).
 # GITHUB_RUN_ID is set automatically on GitHub Actions.
 # ref: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
 #

--- a/tools/rapids-github-run-id
+++ b/tools/rapids-github-run-id
@@ -15,7 +15,7 @@
 # Additional environment variables recognized by 'rapids-github-run-id':
 #
 #   * RAPIDS_BUILD_WORKFLOW_NAME = Filename for the workflow that the run corresponds to.
-#                                  Defaults to 'pr.yaml' for RAPIDS_BUILD_TYPE="pull-request" and 'build.yaml' otherwise).
+#                                  Defaults to 'pr.yaml' for RAPIDS_BUILD_TYPE="pull-request" and 'build.yaml' otherwise.
 #
 set -euo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-github-run-id"

--- a/tools/rapids-prompt-local-github-auth
+++ b/tools/rapids-prompt-local-github-auth
@@ -1,4 +1,5 @@
 #!/bin/bash
+#
 # A utility script that prompts user to authenticate with GitHub in
 # local environments
 

--- a/tools/rapids-prompt-local-repo-config
+++ b/tools/rapids-prompt-local-repo-config
@@ -7,15 +7,15 @@
 #
 # Variables:
 #
-#   * RAPIDS_BUILD_TYPE          = One of "branch", "nightly", or "pull-request".
-#   * RAPIDS_NIGHTLY_DATE        = Date in YYYY-MM-DD format, used to organize nightly uploads.
-#                                  If not provided, the current system time is used.
-#                                  Only used when `RAPIDS_BUILD_TYPE` is "nightly".
-#   * RAPIDS_REF_NAME            = Branch or tag (e.g. "branch-25.08" or "pull-request/1234")
-#   * RAPIDS_REPOSITORY          = Repository the run happened in, in {org}/{repo} format (e.g. "rapidsai/rmm")
-#   * RAPIDS_SHA                 = Commit SHA on the repository indicated by `RAPIDS_REPOSITORY`.
-#                                  If not provided, this script assumes it's being run from within that repo
-#                                  and checks the commit pointed to by HEAD.
+#   * RAPIDS_BUILD_TYPE   = One of "branch", "nightly", or "pull-request".
+#   * RAPIDS_NIGHTLY_DATE = Date in YYYY-MM-DD format, used to organize nightly uploads.
+#                           If not provided, the current system time is used.
+#                           Only used when `RAPIDS_BUILD_TYPE` is "nightly".
+#   * RAPIDS_REF_NAME     = Branch or tag (e.g. "branch-25.08" or "pull-request/1234")
+#   * RAPIDS_REPOSITORY   = Repository the run happened in, in {org}/{repo} format (e.g. "rapidsai/rmm")
+#   * RAPIDS_SHA          = Commit SHA on the repository indicated by `RAPIDS_REPOSITORY`.
+#                           If not provided, this script assumes it's being run from within that repo
+#                           and checks the commit pointed to by HEAD.
 #
 
 if [ "${CI:-false}" = "false" ]; then

--- a/tools/rapids-prompt-local-repo-config
+++ b/tools/rapids-prompt-local-repo-config
@@ -1,6 +1,22 @@
 #!/bin/bash
-# A utility script that prompts user to setup repository information in
-# local environments
+# Sets environment variables reused by other scripts here to interact with
+# git, the GitHub API, and external artifact storage.
+#
+# If those variables are already defined when this script is called, it will not overwrite them.
+# If not, it prompts interactively for them.
+#
+# Variables:
+#
+#   * RAPIDS_BUILD_TYPE          = One of "branch", "nightly", or "pull-request".
+#   * RAPIDS_NIGHTLY_DATE        = Date in YYYY-MM-DD format, used to organize nightly uploads.
+#                                  If not provided, the current system time is used.
+#                                  Only used when `RAPIDS_BUILD_TYPE` is "nightly".
+#   * RAPIDS_REF_NAME            = Branch or tag (e.g. "branch-25.08" or "pull-request/1234")
+#   * RAPIDS_REPOSITORY          = Repository the run happened in, in {org}/{repo} format (e.g. "rapidsai/rmm")
+#   * RAPIDS_SHA                 = Commit SHA on the repository indicated by `RAPIDS_REPOSITORY`.
+#                                  If not provided, this script assumes it's being run from within that repo
+#                                  and checks the commit pointed to by HEAD.
+#
 
 if [ "${CI:-false}" = "false" ]; then
   rapids-echo-stderr "Local run detected."


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-infra/issues/237

Proposes the following changes to scripts involved in handling GitHub Actions artifacts:

* in `rapids-github-run-id`, implements explicit sorting to get the latest run
  - *see inline thread*
* removes `--created-at` from `rapids-github-run-id` code for nightly builds
  - *see inline thread*
* expands documentation in `rapids-github-run-id`  and `rapids-prompt-local-repo-config`
* across multiple scripts, removes phrase "A utility script that..." from the beginning of docs
  - *this does not add any information*

## Notes for Reviewers

### How I tested this

Looked for a repo that doesn't get a lot of commits, so I could test that case where one query with `gh run list` was likely to return multiple runs for the same commit.

Chose this `cugraph-gnn` commit: https://github.com/rapidsai/cugraph-gnn/commit/33bccfe413357deeb4938d8c54182edaca59b1f0

Sure enough, there were multiple runs for it.

```shell
RAPIDS_BUILD_TYPE="nightly" \
RAPIDS_REPOSITORY="rapidsai/cugraph-gnn" \
RAPIDS_REF_NAME="branch-25.06" \
RAPIDS_SHA="33bccfe413357deeb4938d8c54182edaca59b1f0" 
gh run list \
    --repo "${RAPIDS_REPOSITORY}" \
    --branch "${RAPIDS_REF_NAME}" \
    --commit "${RAPIDS_SHA}" \
    --workflow "build.yaml"
```

Output:

```text
STATUS  TITLE  WORKFLOW  BRANCH        EVENT              ID           ELAPSED  AGE             
✓       build  build     branch-25.06  workflow_dispatch  14878118285  26m40s   about 1 day ago
✓       build  build     branch-25.06  workflow_dispatch  14855651986  34m43s   about 2 days ago
✓       build  build     branch-25.06  workflow_dispatch  14830840366  27m25s   about 3 days ago
✓       build  build     branch-25.06  workflow_dispatch  14818738942  26m11s   about 4 days ago
✓       build  build     branch-25.06  workflow_dispatch  14809159545  30m33s   about 5 days ago
✓       build  build     branch-25.06  workflow_dispatch  14791168607  26m35s   about 6 days ago
✓       build  build     branch-25.06  workflow_dispatch  14777188917  27m26s   about 7 days ago
X       build  build     branch-25.06  workflow_dispatch  14777127020  3m28s    about 7 days ago
```

In this case, run `14878118285` is the latest, and so the one we want.

Tested that that's what is returned:

```shell
RAPIDS_BUILD_TYPE="nightly" \
RAPIDS_REPOSITORY="rapidsai/cugraph-gnn" \
RAPIDS_REF_NAME="branch-25.06" \
RAPIDS_SHA="33bccfe413357deeb4938d8c54182edaca59b1f0" \
rapids-github-run-id

# 14878118285
```

I've also tested this in an `rmm` PR: https://github.com/rapidsai/rmm/pull/1909

Look at the most recent run from there: https://github.com/rapidsai/rmm/actions/runs/14914562796/job/41897151092?pr=1909

The run ID (`14914562796`) in the `conda-cpp-tests` logs matches the one in the job URL... so I think it's finding the right thing, at least for PRs.