### PR TITLE
update handling of GitHub auth for local, interactive use

### DIFF
--- a/tools/_rapids-get-pr-artifact-github
+++ b/tools/_rapids-get-pr-artifact-github
@@ -20,6 +20,8 @@ if [[ "${package_format}" = "wheel" && -z "${RAPIDS_PY_WHEEL_NAME:+placeholder}"
     exit 1
 fi
 
+source rapids-prompt-local-github-auth
+
 # If commit is not provided, get the latest commit on the PR
 if [[ -z "${commit}" ]]; then
     commit=$(rapids-retry --quiet gh pr view "${pr}" --repo rapidsai/"${repo}" --json headRefOid --jq '.headRefOid')

--- a/tools/rapids-download-conda-from-github
+++ b/tools/rapids-download-conda-from-github
@@ -8,7 +8,6 @@ set -euo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-download-conda-from-github"
 
 source rapids-prompt-local-repo-config
-source rapids-prompt-local-github-auth
 
 # Validate package type argument
 pkg_type="$1"

--- a/tools/rapids-download-from-github
+++ b/tools/rapids-download-from-github
@@ -6,10 +6,12 @@
 set -euo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-download-from-github"
 
-if [ -z "$1" ]; then
+if [ -z "${1:-}" ]; then
   rapids-echo-stderr "Must specify input arguments: PKG_NAME"
   exit 1
 fi
+
+source rapids-prompt-local-github-auth
 
 github_run_id="$(rapids-github-run-id)"
 pkg_name="$1"

--- a/tools/rapids-download-wheels-from-github
+++ b/tools/rapids-download-wheels-from-github
@@ -8,7 +8,6 @@ set -eo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-download-wheels-from-github"
 
 source rapids-prompt-local-repo-config
-source rapids-prompt-local-github-auth
 
 # Validate package type argument
 pkg_type="$1"

--- a/tools/rapids-github-run-id
+++ b/tools/rapids-github-run-id
@@ -5,6 +5,8 @@
 set -euo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-github-run-id"
 
+source rapids-prompt-local-github-auth
+
 # While called by CI, all the environment variables are set by the caller. However when run locally, these environment variables are set by rapids-prompt-local-repo-config
 case "${RAPIDS_BUILD_TYPE}" in
   pull-request)

--- a/tools/rapids-prompt-local-github-auth
+++ b/tools/rapids-prompt-local-github-auth
@@ -1,9 +1,30 @@
 #!/bin/bash
-# A utility script that prompts user to authenticate with GitHub in
-# local environments
+#
+# Checks if the current environment is authenticated to communicate with the GitHub API.
+#
+# If not, prompts for an interactive login to generate short-lived credentials.
+#
+# This exists primarily for interactive use cases, like trying to reproduce CI locally.
+#
 
-if [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
-  rapids-echo-stderr "No GitHub token detected in environment"
-  rapids-echo-stderr "Please authenticate with GitHub to continue"
-  gh auth login --web --git-protocol https
+if ! gh auth status >/dev/null 2>&1; then
+    rapids-echo-stderr "No GitHub authentication detected."
+    rapids-echo-stderr "Please authenticate with GitHub to continue."
+    rapids-echo-stderr "To avoid these interactive prompts in the future, set environment variable 'GH_TOKEN' or run 'gh auth login' with the GitHub CLI."
+
+    # Prompt for interactive login.
+    #
+    # By omitting --scopes, this will generate a short-lived GitHub auth token
+    # with only the minimum required scopes.
+    #
+    # You can run 'gh auth status' afterwards to check the scopes the GitHub CLI granted.
+    if ! gh auth login \
+        --web \
+        --git-protocol https \
+        --hostname "github.com" \
+        --skip-ssh-key;
+    then
+        rapids-echo-stderr "GitHub authentication failed. Exiting.";
+        exit 1;
+    fi
 fi


### PR DESCRIPTION
Closes #171

Contributes to https://github.com/rapidsai/build-infra/issues/237

Replaces #168

Some of the scripts in this project use the GitHub CLI. Those require authentication with GitHub.

In CI jobs, that authentication is provided by setting environment variable `GH_TOKEN`. When using the scripts interactively (e.g., when reproducing CI), it'd be helpful to prompt for an interactive login flow if the local environment isn't already authenticated.

This does that, via that following:

* in `rapids-prompt-local-github-auth`, prompts for interactive authentication if not currently auth'd with GitHub (determined via `gh auth status`)
* invokes `rapids-prompt-local-github-auth` in every script that uses the GitHub CLI and which might be called interactively (so excludes `rapids-upload-to-anaconda-github`, for example)

## Notes for Reviewers

### How I tested this

Logged out of GitHub locally.

```shell
unset GH_TOKEN
gh auth logout

gh auth status
# You are not logged into any GitHub hosts. To log in, run: gh auth login
```

Tried to download some `rmm` conda packages.

```shell
RAPIDS_BUILD_WORKFLOW_NAME="build.yaml" \
RAPIDS_BUILD_TYPE="branch" \
RAPIDS_REPOSITORY="rapidsai/rmm" \
RAPIDS_REF_NAME="branch-25.06" \
RAPIDS_SHA="dbd8cc7a5f2230a21551670106d4bcd5e507441e" \
rapids-download-from-github \
    rmm_conda_python_cuda12_py312_aarch64
```

Got an interactive prompt to login:

![Screenshot from 2025-05-08 16-15-21](https://github.com/user-attachments/assets/21d2b6c0-956b-48a6-a6a7-106209c544b4)

Followed that flow, then was logged in and saw packages download successfully.

Ran that same `rapids-download-from-github` command again, saw the downloads work and NOT re-prompt for auth.

Logged out again, then set the `GH_TOKEN` environment variable to a GitHub "classic" token ([docs](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)) that only had the `repo` scope.

```shell
 export GH_TOKEN=<redacted>
gh auth status
```

Confirming that it only had the `repo` scope:

```text
  ✓ Logged in to github.com account jameslamb (GH_TOKEN)
  - Active account: true
  - Git operations protocol: https
  - Token: ghp_************************************
  - Token scopes: 'repo'
  ! Missing required token scopes: 'read:org'
  - To request missing scopes, run: gh auth refresh -h github.com
```

Running the same `rapids-download-from-github` command as above worked, without re-prompting for auth.

Also tested this in an `rmm` PR:

* PR: https://github.com/rapidsai/rmm/pull/1909
* build link: https://github.com/rapidsai/rmm/actions/runs/14916596953/job/41903518506?pr=1909
