### PR TITLE
Update gha-tools for new RAPIDS branching strategy

### DIFF
--- a/tools/rapids-s3-path
+++ b/tools/rapids-s3-path
@@ -9,7 +9,15 @@
 ## s3://rapids-downloads/ci/<REPO_NAME>/pull-request/<PR_NUMBER>/<SHORT_HASH>/
 
 ## For branch builds:
-## s3://rapids-downloads/ci/<REPO_NAME>/branch/<BRANCH_NAME>/<SHORT_HASH>/
+## s3://rapids-downloads/ci/<REPO_NAME>/<TYPE>/<IDENTIFIER>/<SHORT_HASH>/
+## where TYPE is one of:
+##   - main (for main branch)
+##   - release (for release/YY.MM branches)
+##   - branch (for legacy branch-YY.MM branches)
+## and IDENTIFIER is:
+##   - main (for main branch)
+##   - YY.MM (for release/YY.MM branches)
+##   - branch-YY.MM (for legacy branch-YY.MM branches)
 
 ## For nightly builds:
 ## s3://rapids-downloads/nightly/<REPO_NAME>/<DATE>/<SHORT_HASH>/
@@ -20,6 +28,7 @@ export RAPIDS_SCRIPT_NAME="rapids-s3-path"
 repo_name="${RAPIDS_REPOSITORY##*/}"
 
 s3_directory_id=""
+s3_type_path_segment=""
 s3_prefix=""
 
 case "${RAPIDS_BUILD_TYPE}" in
@@ -29,12 +38,25 @@ case "${RAPIDS_BUILD_TYPE}" in
     # more info:
     #    CopyPRs plugin in ops-bot: https://github.com/rapidsai/ops-bot#plugins
     #    https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
+    s3_type_path_segment="pull-request"
     s3_directory_id="${RAPIDS_REF_NAME##*/}"
     s3_prefix="ci"
     ;;
   branch)
-    s3_directory_id="${RAPIDS_REF_NAME}"
     s3_prefix="ci"
+    if [[ "${RAPIDS_REF_NAME}" == "main" ]]; then
+      s3_type_path_segment="main"
+      s3_directory_id="main"
+    elif [[ "${RAPIDS_REF_NAME}" == release/* ]]; then
+      s3_type_path_segment="release"
+      s3_directory_id="${RAPIDS_REF_NAME#release/}"
+    elif [[ "${RAPIDS_REF_NAME}" == branch-* ]]; then # Legacy branches
+      s3_type_path_segment="branch"
+      s3_directory_id="${RAPIDS_REF_NAME}"
+    else
+      rapids-echo-stderr "Error: Unknown branch name format for RAPIDS_BUILD_TYPE 'branch': ${RAPIDS_REF_NAME}"
+      exit 1
+    fi
     ;;
   nightly)
     s3_directory_id="${RAPIDS_NIGHTLY_DATE}"
@@ -50,7 +72,7 @@ short_hash=${RAPIDS_SHA:0:7}
 
 s3_path="s3://${RAPIDS_DOWNLOADS_BUCKET}/${s3_prefix}/${repo_name}/"
 if [[ "${RAPIDS_BUILD_TYPE}" != "nightly" ]]; then
-  s3_path+="${RAPIDS_BUILD_TYPE}/"
+  s3_path+="${s3_type_path_segment}/"
 fi
 s3_path+="${s3_directory_id}/${short_hash}/"
 


### PR DESCRIPTION
Updates `gha-tools` to support the new RAPIDS branching strategy while maintaining backward compatibility with the existing strategy. The new strategy involves:
- Persistent `main` branch
- `release/YY.MM` branches for releases
- Legacy `branch-YY.MM` support maintained

## Changes
The primary change is to `rapids-s3-path` to handle the new branch types:

```bash
# For RAPIDS_BUILD_TYPE = branch:
if [[ "${RAPIDS_REF_NAME}" == "main" ]]; then
  s3_type_path_segment="main"
  s3_identifier="main"
elif [[ "${RAPIDS_REF_NAME}" == release/* ]]; then
  s3_type_path_segment="release"
  s3_identifier="${RAPIDS_REF_NAME#release/}" # e.g., 25.02
elif [[ "${RAPIDS_REF_NAME}" == branch-* ]]; then # Legacy branches
  s3_type_path_segment="branch"
  s3_identifier="${RAPIDS_REF_NAME}"
else
  rapids-echo-stderr "Error: Unknown branch name format for RAPIDS_BUILD_TYPE 'branch': ${RAPIDS_REF_NAME}"
  exit 1
fi
```

This change ensures:
- `main` branch builds go to `s3://<bucket>/ci/<repo>/main/main/<hash>/`
- `release/YY.MM` builds go to `s3://<bucket>/ci/<repo>/release/YY.MM/<hash>/`
- Legacy `branch-YY.MM` builds continue to use `s3://<bucket>/ci/<repo>/branch/branch-YY.MM/<hash>/`

## Notes
- No changes needed to `rapids-upload-docs` as it already uses `RAPIDS_VERSION_NUMBER` correctly to determine docs location regardless of branch.
- No changes needed to `rapids-upload-to-anaconda`, `rapids-is-release-build`, `rapids-version`, and `rapids-generate-version`. These are already compatible with the new strategy
- From my perusal, I think there are no tools to be updated asides the one update in this PR.