### PR TITLE
rapids-rattler-channel-string: add support for prepending channels

### DIFF
--- a/tools/rapids-rattler-channel-string
+++ b/tools/rapids-rattler-channel-string
@@ -1,5 +1,38 @@
 #!/bin/bash
 
+# Populates shell variables expected to be used by build scripts invoking `ratther-build`.
+#
+# This is intended to be `source`'d, not invoked as an executable.
+#
+# Variables:
+#
+#   * RATTLER_ARGS     = Bash array of arguments to be passed to invocations of `rattler-build build`
+#   * RATTLER_CHANNELS = Bash array of conda channels, where each item is prefixed with '--channel '.
+#                        If variable `RAPIDS_PREPENDED_CONDA_CHANNELS` is defined when this script is invoked,
+#                        it is expected to hold a bash array with additional conda channels (omitting the '--channel ' prefix).
+#                        Each of these is PREPENDED to the output in `RATTLER_CHANNELS`.
+#
+# Usage:
+#
+#   # standard usage
+#   source rapids-rattler-channel-string
+#   rattler-build build                           \
+#     --recipe conda/recipes/librmm               \
+#     --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \
+#     "${RATTLER_CHANNELS[@]}"
+#
+#   # prepend custom channels
+#   LIBRMM_CHANNEL=$(rapids-get-pr-conda-artifact rmm 1909 cpp)
+#   RMM_CHANNEL=$(rapids-get-pr-conda-artifact rmm 1909 python)
+#   RAPIDS_PREPENDED_CONDA_CHANNELS=("${LIBRMM_CHANNEL}" "${RMM_CHANNEL}")
+#
+#   source rapids-rattler-channel-string
+#   rattler-build build                           \
+#     --recipe conda/recipes/librmm               \
+#     --output-dir "$RAPIDS_CONDA_BLD_OUTPUT_DIR" \
+#     "${RATTLER_CHANNELS[@]}"
+#
+
 RAPIDS_CHANNEL="rapidsai-nightly"
 NVIDIA_CHANNEL=""
 
@@ -19,7 +52,17 @@ if [ "${CUDA_VERSION_ARRAY[0]}" -eq "11" ]; then
   CHANNEL_PRIORITY="disabled"
 fi
 
-channels=("$RAPIDS_CHANNEL" "conda-forge" "$NVIDIA_CHANNEL")
+# Process extra channels, prepended to work with strict channel priority.
+#
+# This is here, for example, to support customizations in CI like
+# "download these packages from another source and ensure they're used".
+#
+channels=()
+if [[ -n "${RAPIDS_PREPENDED_CONDA_CHANNELS:-}" ]]; then
+  channels+=("${RAPIDS_PREPENDED_CONDA_CHANNELS[@]}");
+fi
+
+channels+=("$RAPIDS_CHANNEL" "conda-forge" "$NVIDIA_CHANNEL")
 
 _add_c_prefix() {
   for channel in "${channels[@]}"; do

--- a/tools/rapids-rattler-channel-string
+++ b/tools/rapids-rattler-channel-string
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Populates shell variables expected to be used by build scripts invoking `ratther-build`.
+# Populates shell variables expected to be used by build scripts invoking `rattler-build`.
 #
 # This is intended to be `source`'d, not invoked as an executable.
 #


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-infra/issues/237

Contributes to https://github.com/rapidsai/build-planning/issues/14

Splitting this off from #/173

## Overview

As of this PR, if a bash array `RAPIDS_PREPENDED_CONDA_CHANNELS` is detected whenever `rapids-rattler-channel-string` is sourced, it prepends each element of that array the channel list passed to `rattler-build` (`RATTLER_CHANNELS`).

## Notes for Reviewers

### Benefits of these changes

Helps with simplifying "use packages from one PR in another PR's CI" (related: https://github.com/rapidsai/docs/pull/601).

With this, you could create a script like `ci/use_conda_packages_from_prs.sh` and `source` it at the top of every `ci/build*.sh`, without any other changes to `ci/build*.sh` scripts required:

```shell
# download CI artifacts
LIBRAFT_CHANNEL=$(rapids-get-pr-conda-artifact raft 789 python)
LIBRMM_CHANNEL=$(rapids-get-pr-conda-artifact rmm 1909 cpp)

# For `rattler` builds:
#
# Add these channels to the array checked by 'rapids-rattler-channel-string'.
RAPIDS_PREPENDED_CONDA_CHANNELS=(
    "${LIBRAFT_CHANNEL}"
    "${LIBRMM_CHANNEL}"
)
export RAPIDS_PREPENDED_CONDA_CHANNELS

# For tests and `conda-build` builds:
#
# Add these channels to the system-wide conda configuration.
for _channel in "${RAPIDS_PREPENDED_CONDA_CHANNELS[@]}"
do
   conda config --system --add channels "${_channel}"
done
```

### More Details

`rapids-rattler-channel-string` (first added in #143) defines a bash array, `RATTLER_CHANNELS`, containing a list of conda channels to be used when building the build/host/test environments in `rattler-build` builds. Like this:

```shell
source rapids-rattler-channel-string
rattler-build build --recipe conda/recipes/cuml \
                    "${RATTLER_ARGS[@]}" \
                    "${RATTLER_CHANNELS[@]}"
```

([cuml code link](https://github.com/rapidsai/cuml/blob/7ef66c4f01c48967d60a2c9db6ce03ba5f532373/ci/build_python.sh#L37-L39))

The **ordering in that channel list is important**... for any projects using conda "strict" channel priority, those channels are searched in order for packages, and the first package found is used.

When testing something like "use packages from this `cuvs` PR in CI on this `cuml` PR", it's desirable to download the upstream PR's CI artifacts and tell `rattler-build` to use them. One useful mechanism for that is to put the "channels" (local directories) holding those downloaded files into the channel list. It's important that you be able to **prepend** them, so strict channel priority will result in the locally-downloaded packages being chosen.

This change makes that possible for `rattler-build` builds (see above and https://github.com/rapidsai/docs/pull/601).

### How I tested this

Tested this as part of https://github.com/rapidsai/gha-tools/pull/173, via https://github.com/rapidsai/cudf/pull/18747

Evidence that it worked: https://github.com/rapidsai/cudf/pull/18747#issuecomment-2878495784