### PR TITLE
use pre-commit in CI, other CI changes

### DIFF
--- a/.github/workflows/prs.yaml
+++ b/.github/workflows/prs.yaml
@@ -17,11 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
-        with:
-          scandir: "./tools"
-          ignore_paths: "**.py"
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
       - name: Check Permissions
         run: |
           # Executable bit indices
@@ -37,14 +34,11 @@ jobs:
                 ls -l tools/
                 echo ""
                 echo "${FILE} does not have the correct permissions."
-                echo "Ensure are tools are executable by everyone and try again."
+                echo "Ensure all tools are executable by everyone and try again."
                 exit 1
               fi
             done
           done
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
       - name: Run pytest
         run: |
           pip install pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.9
+    hooks:
+      - id: ruff-format
+        args: ["--config", "pyproject.toml"]
+      - id: ruff
+        args: ["--config", "pyproject.toml", "--fix"]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 'v5.0.0'
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-builtin-literals
+      - id: debug-statements
+      - id: requirements-txt-fixer
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ["--rcfile", ".shellcheckrc"]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The `gpuci_*` tools in this project are wrappers around the new tools for backwa
 This project contains some scripts for managing CI artifacts.
 
 * `rapids-download-{conda,wheels}-from-github`: download conda packages and wheels from the GitHub Actions artifact store
-* `rapids-upload-to-anaconda-github`: downloads conda packages from GitHub Actions artifact store and uploads conda channels on anaconda.org 
+* `rapids-upload-to-anaconda-github`: downloads conda packages from GitHub Actions artifact store and uploads conda channels on anaconda.org
 * `rapids-wheels-anaconda-github`: downloads wheels from GitHub Actions artifact store and uploads them to the RAPIDS nightly index at https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/
 * `rapids-package-name`: takes a package type and generate the artifact name (e.g. `conda_cpp` -> `rmm_conda_cpp_x86_64.tar.gz`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.ruff]
+fix = true
+indent-width = 4
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    # pycodestyle
+    "E",
+    # pyflakes
+    "F",
+    # isort
+    "I",
+    # numpy
+    "NPY",
+    # flake8-bugbear
+    "B"
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/test_rapids-check-pr-job-dependencies.py" = [
+    # (pycodstyle) line too long
+    "E501"
+]

--- a/tests/test_rapids-check-pr-job-dependencies.py
+++ b/tests/test_rapids-check-pr-job-dependencies.py
@@ -1,7 +1,8 @@
 import os.path
-import pytest
 import subprocess
 from textwrap import dedent
+
+import pytest
 
 TOOLS_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "tools")
 
@@ -76,7 +77,7 @@ TOOLS_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "too
                 """\
                 'pr-builder' job is missing the following dependent jobs:
                   - job3
-                
+
                 Update '{filename}' to include these missing jobs for 'pr-builder'.
                 Alternatively, you may ignore these jobs by passing them as an argument to this script.
                 """
@@ -100,7 +101,7 @@ TOOLS_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "too
             dedent(
                 """\
                 If 'pr-builder' job has an 'if' condition, it must be set to 'always()'.
-                
+
                 Update '{filename}' to set the correct 'if' condition.
                 """
             ),
@@ -123,7 +124,7 @@ TOOLS_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "too
             dedent(
                 """\
                 If 'pr-builder' job has an 'if' condition, it must also set the 'needs' input to '${{{{ toJSON(needs) }}}}'.
-                
+
                 Update '{filename}' to add the following:
 
                 with:
@@ -150,7 +151,7 @@ TOOLS_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "too
             dedent(
                 """\
                 If 'pr-builder' job has an 'if' condition, it must also set the 'needs' input to '${{{{ toJSON(needs) }}}}'.
-                
+
                 Update '{filename}' to add the following:
 
                 with:
@@ -178,7 +179,7 @@ TOOLS_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "too
             dedent(
                 """\
                 If 'pr-builder' job has an 'if' condition, it must also set the 'needs' input to '${{{{ toJSON(needs) }}}}'.
-                
+
                 Update '{filename}' to add the following:
 
                 with:

--- a/tests/test_rapids-find-anaconda-uploads.py
+++ b/tests/test_rapids-find-anaconda-uploads.py
@@ -1,8 +1,9 @@
+import importlib
 import sys
 from os import environ, path
-import importlib
-import pytest
 from unittest import mock
+
+import pytest
 
 tools_dir = path.join(path.dirname(path.realpath(__file__)), "..", "tools")
 sys.path.insert(0, tools_dir)
@@ -74,9 +75,7 @@ def test_file_filter_fn():
     file_filter_fn = mod.file_filter_fn
 
     # w/ env var
-    with mock.patch.dict(
-        environ, {"SKIP_UPLOAD_PKGS": "some-pkg-private libcudf-tests"}
-    ):
+    with mock.patch.dict(environ, {"SKIP_UPLOAD_PKGS": "some-pkg-private libcudf-tests"}):
         filtered_list = list(filter(file_filter_fn, TEST_FILES))
         assert filtered_list == [
             "./cudf_conda_python_cuda11_39_x86_64/linux-64/some-pkg-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",

--- a/tests/test_rapids-version.py
+++ b/tests/test_rapids-version.py
@@ -1,17 +1,21 @@
-from os import path
-import pytest
 import subprocess
 import tempfile
+from os import path
+
+import pytest
 
 TOOLS_DIR = path.join(path.dirname(path.realpath(__file__)), "..", "tools")
 
 
 def run_rapids_version(tool_name, cwd, exit_code, output):
-    process = subprocess.Popen([path.join(TOOLS_DIR, tool_name)], cwd=cwd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(
+        [path.join(TOOLS_DIR, tool_name)], cwd=cwd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     process.wait()
     assert process.returncode == exit_code
     assert process.stdout.read() == output
     assert process.stderr.read() == ""
+
 
 @pytest.mark.parametrize(
     "version_contents, exit_code, version, version_major_minor",
@@ -21,7 +25,7 @@ def run_rapids_version(tool_name, cwd, exit_code, output):
         ("invalid\n", 1, "", ""),
         ("", 1, "", ""),
         (None, 1, "", ""),
-    ]
+    ],
 )
 def test_rapids_version(version_contents, exit_code, version, version_major_minor):
     with tempfile.TemporaryDirectory() as d:

--- a/tools/rapids-download-from-github
+++ b/tools/rapids-download-from-github
@@ -19,6 +19,6 @@ pkg_name="$1"
 unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 
 rapids-echo-stderr "Downloading and decompressing ${pkg_name} from Run ID ${github_run_id} into ${unzip_dest}"
-rapids-retry gh run download "${github_run_id}" --repo "${RAPIDS_REPOSITORY}" --name "${pkg_name}" --dir "${unzip_dest}" 
+rapids-retry gh run download "${github_run_id}" --repo "${RAPIDS_REPOSITORY}" --name "${pkg_name}" --dir "${unzip_dest}"
 
 echo -n "${unzip_dest}"

--- a/tools/rapids-find-anaconda-uploads.py
+++ b/tools/rapids-find-anaconda-uploads.py
@@ -54,9 +54,8 @@ def file_filter_fn(file_path):
 
 if __name__ == "__main__":
     directory_to_search = sys.argv[1]
-    conda_pkgs = (
-        glob.glob(f"{directory_to_search}/**/*.conda", recursive=True) +
-        glob.glob(f"{directory_to_search}/**/*.tar.bz2", recursive=True)
+    conda_pkgs = glob.glob(f"{directory_to_search}/**/*.conda", recursive=True) + glob.glob(
+        f"{directory_to_search}/**/*.tar.bz2", recursive=True
     )
 
     filtered_list = list(filter(file_filter_fn, conda_pkgs))

--- a/tools/rapids-upload-to-anaconda-github
+++ b/tools/rapids-upload-to-anaconda-github
@@ -29,7 +29,7 @@ for artifact_dir in "${unzip_dest}"/*/; do
 
   # Find packages to upload
   PKGS_TO_UPLOAD=$(rapids-find-anaconda-uploads.py "${artifact_dir}")
-  
+
   if [ -z "${PKGS_TO_UPLOAD}" ]; then
     rapids-echo-stderr "Couldn't find any packages to upload in: ${artifact_dir}"
     ls -l "${artifact_dir}/"*


### PR DESCRIPTION
I've been working in this repo a lot recently, and found myself really wanting the development workflow from so many other RAPIDS repos, where you can run most linting locally with a single command (`pre-commit run --all-files`).

This proposes the following:

* using `pre-commit` to run `shellcheck`, instead of the third-party action https://github.com/ludeeus/action-shellcheck
* adding more linters:
  - `ruff` - linting and auto-formatting Python code
  - `pre-commit/pre-commit-hooks` - for generic stuff like trailing whitespace and ensuring every file ends in a newline
* using the system `python` on GitHub's `ubuntu-latest` instead of invoking `actions/setup-python` to run tests