### PR TITLE
make anaconda upload scripts stricter

### DIFF
--- a/tools/rapids-upload-to-anaconda-github
+++ b/tools/rapids-upload-to-anaconda-github
@@ -1,6 +1,6 @@
 #!/bin/bash
-# A utility script that uploads all the conda packages from a
-# GitHub Actions workflow run to Anaconda.org
+# Uploads all the conda packages from a GitHub Actions workflow run to Anaconda.org
+
 set -euo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-upload-to-anaconda-github"
 
@@ -18,8 +18,12 @@ esac
 github_run_id="$(rapids-github-run-id)"
 unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 
-#Download all artifacts with conda in the name to unzip_dest
-rapids-retry gh run download "${github_run_id}" --repo "${RAPIDS_REPOSITORY}" --dir "${unzip_dest}" --pattern "*conda*"
+# Download all artifacts with conda in the name to unzip_dest
+rapids-retry gh run download    \
+  "${github_run_id}"            \
+  --repo "${RAPIDS_REPOSITORY}" \
+  --dir "${unzip_dest}"         \
+  --pattern '*conda*'
 
 # Find all directories within unzip_dest
 for artifact_dir in "${unzip_dest}"/*/; do

--- a/tools/rapids-wheels-anaconda-github
+++ b/tools/rapids-wheels-anaconda-github
@@ -1,9 +1,9 @@
 #!/bin/bash
-# A utility script to upload Python wheel packages to Anaconda repository using anaconda-client.
-
+# Uploads Python wheels from a GitHub Actions workflow run to Anaconda.org
+#
 # Positional Arguments:
 #   1) wheel name
-#   2) package type (one of: 'cpp', 'python'). If not provided, defaults to 'python' for compatibility with older code where python was the only behavior.
+#   2) package type (one of: 'cpp', 'python')
 #
 # [usage]
 #
@@ -18,8 +18,8 @@ if [ -z "$1" ]; then
   rapids-echo-stderr "Must specify input arguments: WHEEL_NAME"
   exit 1
 fi
-WHEEL_NAME="$1"
-PKG_TYPE="${2:-python}"
+WHEEL_NAME="${1}"
+PKG_TYPE="${2}"
 
 case "${PKG_TYPE}" in
   cpp)
@@ -42,8 +42,12 @@ unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 
 rapids-echo-stderr "Downloading ${PKG_TYPE}_${WHEEL_NAME} wheels to ${unzip_dest}"
 
-#Download all artifacts with WHEEL_SEARCH_KEY in the name to unzip_dest
-rapids-retry gh run download "${github_run_id}" --repo "${RAPIDS_REPOSITORY}" --dir "${unzip_dest}" --pattern "*${WHEEL_SEARCH_KEY}*"
+# Download all artifacts with WHEEL_SEARCH_KEY in the name to unzip_dest
+rapids-retry gh run download        \
+  "${github_run_id}"                \
+  --repo "${RAPIDS_REPOSITORY}"     \
+  --dir "${unzip_dest}"             \
+  --pattern "*${WHEEL_SEARCH_KEY}*"
 
 find "${unzip_dest}" -name "*.whl" -exec cp {} "${WHEEL_DIR}/" \;
 
@@ -54,7 +58,7 @@ if [ "${wheel_count}" -eq 0 ]; then
   exit 1
 fi
 
-# Upload all wheels using the array
+# Upload all wheels
 rapids-echo-stderr "Uploading ${wheel_count} wheels to Anaconda.org"
 export RAPIDS_RETRY_SLEEP=180
 # shellcheck disable=SC2086
@@ -64,4 +68,5 @@ rapids-retry anaconda \
     --skip-existing \
     --no-progress \
     "${WHEEL_DIR}"/*.whl
+
 echo ""


### PR DESCRIPTION
`rapids-wheels-anaconda-github` takes 2 positional arguments:

1. wheel name (distribution name without qualifiers, like `pylibcudf`)
2. package type (one of `cpp` or `python`)

Package type is currently *optional* and defaults to `python`, I think because that script was copied from `rapids-wheels-anaconda` which does that:

https://github.com/rapidsai/gha-tools/blob/3794c746b216ec38de375320c803d316873a0781/tools/rapids-wheels-anaconda#L23

`rapids-wheels-anaconda-github` is not currently used anywhere ([GitHub search](https://github.com/search?q=org%3Arapidsai%20%22rapids-wheels-anaconda-github%22&type=code)), so that script doesn't need this extra flexibility.

This proposes making all positional options to it required right now, to reduce number of different paths configuration can flow through.

Other changes:

* simplifies documentation
* minor formatting and code-commenting changes for clarity