### PR TITLE
add fallbacks in checks with '-z'

### DIFF
--- a/tools/rapids-download-from-s3
+++ b/tools/rapids-download-from-s3
@@ -7,7 +7,7 @@
 set -euo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-download-from-s3"
 
-if [ -z "$1" ] || [ -z "$2" ]; then
+if [ -z "${1:-}" ] || [ -z "${2:-}" ]; then
   rapids-echo-stderr "Must specify input arguments: PKG_NAME and UNTAR_DEST"
   exit 1
 fi

--- a/tools/rapids-extract-conda-files
+++ b/tools/rapids-extract-conda-files
@@ -3,7 +3,7 @@
 set -eo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-extract-conda-files"
 
-if [ -z "$1" ]; then
+if [ -z "${1:-}" ]; then
   rapids-echo-stderr "Must specify input argument: CONDA_PKG_DIR"
   exit 1
 fi

--- a/tools/rapids-package-name
+++ b/tools/rapids-package-name
@@ -7,7 +7,7 @@ export RAPIDS_SCRIPT_NAME="rapids-package-name"
 
 repo_name="${RAPIDS_REPOSITORY##*/}"
 
-if [ -z "$1" ]; then
+if [ -z "${1:-}" ]; then
   rapids-echo-stderr "Must specify input arguments: PKG_TYPE"
   exit 1
 fi

--- a/tools/rapids-pip-wheel-version
+++ b/tools/rapids-pip-wheel-version
@@ -5,7 +5,7 @@
 set -exo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-pip-wheel-version"
 
-if [ -z "$1" ]; then
+if [ -z "${1:-}" ]; then
   rapids-echo-stderr "Must specify input arguments: EPOCH_TIMESTAMP"
   exit 1
 fi

--- a/tools/rapids-upload-to-s3
+++ b/tools/rapids-upload-to-s3
@@ -4,10 +4,10 @@
 #   1) package name
 #   2) path to tar up
 set -eo pipefail
-source rapids-constants
+#source rapids-constants
 export RAPIDS_SCRIPT_NAME="rapids-upload-to-s3"
 
-if [ -z "$1" ] || [ -z "$2" ]; then
+if [ -z "${1:-}" ] || [ -z "${2:-}" ]; then
   rapids-echo-stderr "Must specify both input arguments: PACKAGE_NAME and PATH_TO_TAR_UP"
   exit 1
 fi

--- a/tools/rapids-upload-to-s3
+++ b/tools/rapids-upload-to-s3
@@ -4,7 +4,7 @@
 #   1) package name
 #   2) path to tar up
 set -eo pipefail
-#source rapids-constants
+source rapids-constants
 export RAPIDS_SCRIPT_NAME="rapids-upload-to-s3"
 
 if [ -z "${1:-}" ] || [ -z "${2:-}" ]; then

--- a/tools/rapids-wheel-ctk-name-gen
+++ b/tools/rapids-wheel-ctk-name-gen
@@ -5,7 +5,7 @@
 #   1) ctk tag
 set -eu -o pipefail
 
-if [ -z "${1-}" ]; then
+if [ -z "${1:-}" ]; then
   rapids-echo-stderr "Must specify input argument: CTK_TAG"
   exit 1
 fi

--- a/tools/rapids-wheels-anaconda
+++ b/tools/rapids-wheels-anaconda
@@ -15,7 +15,7 @@ set -eou pipefail
 source rapids-constants
 export RAPIDS_SCRIPT_NAME="rapids-wheels-anaconda"
 
-if [ -z "$1" ]; then
+if [ -z "${1:-}" ]; then
   rapids-echo-stderr "Must specify input arguments: WHEEL_NAME"
   exit 1
 fi

--- a/tools/rapids-wheels-anaconda-github
+++ b/tools/rapids-wheels-anaconda-github
@@ -14,8 +14,8 @@
 set -eou pipefail
 export RAPIDS_SCRIPT_NAME="rapids-wheels-anaconda-github"
 
-if [ -z "$1" ]; then
-  rapids-echo-stderr "Must specify input arguments: WHEEL_NAME"
+if [ -z "${1:-}" ] || [ -z "${2:-}" ]; then
+  rapids-echo-stderr "Must specify input arguments: WHEEL_NAME and PKG_TYPE"
   exit 1
 fi
 WHEEL_NAME="$1"


### PR DESCRIPTION
I've been spending a lot of time in this repo recently and have seen a recurring pattern.

Checks like this:

```bash
if [ -z "$1" ]; then
  echo "you have to pass an argument"
  exit 1
fi
```

If code like that is run when `set -u` is set, that informative error message and other code inside the `then` block will never be executed... bash will exit immediately with an error like "unbound variable ...".

This adds a fallback to null in all such checks I could find, to avoid that.

## Notes for Reviewers

### How I found these

```shell
git grep -E '\-n'
git grep -E '\-z'
```

### Recent Examples

* https://github.com/rapidsai/gha-tools/pull/175#discussion_r2087221650
* https://github.com/rapidsai/gha-tools/pull/172#discussion_r2080487908
* https://github.com/conda-forge/arrow-cpp-feedstock/pull/1696
