### PR TITLE
Revert "fix: add `--quiet` flag to `rapids-retry` call for `gh run download` (#181)"

### DIFF
--- a/tools/rapids-download-from-github
+++ b/tools/rapids-download-from-github
@@ -19,6 +19,6 @@ pkg_name="$1"
 unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 
 rapids-echo-stderr "Downloading and decompressing ${pkg_name} from Run ID ${github_run_id} into ${unzip_dest}"
-rapids-retry --quiet gh run download "${github_run_id}" --repo "${RAPIDS_REPOSITORY}" --name "${pkg_name}" --dir "${unzip_dest}"
+rapids-retry gh run download "${github_run_id}" --repo "${RAPIDS_REPOSITORY}" --name "${pkg_name}" --dir "${unzip_dest}"
 
 echo -n "${unzip_dest}"


### PR DESCRIPTION
This reverts commit 14d7886e1ddb473bcddf5fd9e55c5b3a5375f15f.

Breaking downstream builds
