### PR TITLE
Ensure all extra `rapids-download-from-github` output goes to `stderr`

### DIFF
--- a/tools/rapids-download-from-github
+++ b/tools/rapids-download-from-github
@@ -18,7 +18,12 @@ github_run_id="$(rapids-github-run-id)"
 pkg_name="$1"
 unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 
-rapids-echo-stderr "Downloading and decompressing ${pkg_name} from Run ID ${github_run_id} into ${unzip_dest}"
-rapids-retry gh run download "${github_run_id}" --repo "${RAPIDS_REPOSITORY}" --name "${pkg_name}" --dir "${unzip_dest}"
+# This script should only output `unzip_dest` to `stdout``.
+# Scripts that produce any other output should be sent to `stderr`
+# by adding them to this block.
+{
+  echo "Downloading and decompressing ${pkg_name} from Run ID ${github_run_id} into ${unzip_dest}"
+  rapids-retry gh run download "${github_run_id}" --repo "${RAPIDS_REPOSITORY}" --name "${pkg_name}" --dir "${unzip_dest}"
+} >&2
 
 echo -n "${unzip_dest}"


### PR DESCRIPTION
This PR addresses an issue with `rapids-download-from-github`. That script should only output a folder name to `stdout`. All other output should go to `stderr`. This PR addresses that by redirecting the existing output to `stderr`.