### PR TITLE
display stderr from rapids-prompt-local-github-auth, wait 30 seconds between retries for GitHub calls

### DIFF
--- a/tools/rapids-download-from-github
+++ b/tools/rapids-download-from-github
@@ -23,7 +23,12 @@ unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 # by adding them to this block.
 {
   echo "Downloading and decompressing ${pkg_name} from Run ID ${github_run_id} into ${unzip_dest}"
-  rapids-retry gh run download "${github_run_id}" --repo "${RAPIDS_REPOSITORY}" --name "${pkg_name}" --dir "${unzip_dest}"
+  RAPIDS_RETRY_SLEEP=30             \
+    rapids-retry gh run download    \
+      "${github_run_id}"            \
+      --repo "${RAPIDS_REPOSITORY}" \
+      --name "${pkg_name}"          \
+      --dir "${unzip_dest}"
 } >&2
 
 echo -n "${unzip_dest}"

--- a/tools/rapids-github-run-id
+++ b/tools/rapids-github-run-id
@@ -25,23 +25,27 @@ source rapids-prompt-local-github-auth
 # While called by CI, all the environment variables are set by the caller. However when run locally, these environment variables are set by rapids-prompt-local-repo-config
 case "${RAPIDS_BUILD_TYPE}" in
   pull-request)
-    run_id=${GITHUB_RUN_ID:-$(rapids-retry --quiet gh run list \
-      --repo "${RAPIDS_REPOSITORY}" \
-      --branch "${RAPIDS_REF_NAME}" \
-      --commit "${RAPIDS_SHA}" \
-      --workflow "${RAPIDS_BUILD_WORKFLOW_NAME:-pr.yaml}" \
-      --json 'createdAt,databaseId' \
-      --jq 'sort_by(.createdAt) | reverse | .[0] | .databaseId')}
+    run_id=${GITHUB_RUN_ID:-$(
+      RAPIDS_RETRY_SLEEP=30                                   \
+        rapids-retry --quiet gh run list                      \
+          --repo "${RAPIDS_REPOSITORY}"                       \
+          --branch "${RAPIDS_REF_NAME}"                       \
+          --commit "${RAPIDS_SHA}"                            \
+          --workflow "${RAPIDS_BUILD_WORKFLOW_NAME:-pr.yaml}" \
+          --json 'createdAt,databaseId'                       \
+          --jq 'sort_by(.createdAt) | reverse | .[0] | .databaseId')}
     ;;
   branch)
-    run_id=${GITHUB_RUN_ID:-$(rapids-retry --quiet gh run list \
-      --repo "${RAPIDS_REPOSITORY}" \
-      --branch "${RAPIDS_REF_NAME}" \
-      --commit "${RAPIDS_SHA}" \
-      --workflow "${RAPIDS_BUILD_WORKFLOW_NAME:-build.yaml}" \
-      --event "push" \
-      --json 'createdAt,databaseId' \
-      --jq 'sort_by(.createdAt) | reverse | .[0] | .databaseId')}
+    run_id=${GITHUB_RUN_ID:-$(
+      RAPIDS_RETRY_SLEEP=30                                      \
+        rapids-retry --quiet gh run list                         \
+          --repo "${RAPIDS_REPOSITORY}"                          \
+          --branch "${RAPIDS_REF_NAME}"                          \
+          --commit "${RAPIDS_SHA}"                               \
+          --workflow "${RAPIDS_BUILD_WORKFLOW_NAME:-build.yaml}" \
+          --event "push"                                         \
+          --json 'createdAt,databaseId'                          \
+          --jq 'sort_by(.createdAt) | reverse | .[0] | .databaseId')}
     ;;
   nightly)
     # Notice that for nightly runs, this script intentionally does not return GITHUB_RUN_ID.
@@ -53,14 +57,17 @@ case "${RAPIDS_BUILD_TYPE}" in
     #
     # From GitHub's perspective, those are different "runs", with different IDs.
     # GitHub Actions organizes artifacts by run ID.
-    run_id=$(rapids-retry --quiet gh run list \
-      --repo "${RAPIDS_REPOSITORY}" \
-      --branch "${RAPIDS_REF_NAME}" \
-      --commit "${RAPIDS_SHA}" \
-      --workflow "${RAPIDS_BUILD_WORKFLOW_NAME:-build.yaml}" \
-      --event "workflow_dispatch" \
-      --json 'createdAt,databaseId' \
-      --jq 'sort_by(.createdAt) | reverse | .[0] | .databaseId')
+    run_id=$(
+      RAPIDS_RETRY_SLEEP=30                                      \
+        rapids-retry --quiet gh run list                         \
+          --repo "${RAPIDS_REPOSITORY}"                          \
+          --branch "${RAPIDS_REF_NAME}"                          \
+          --commit "${RAPIDS_SHA}"                               \
+          --workflow "${RAPIDS_BUILD_WORKFLOW_NAME:-build.yaml}" \
+          --event "workflow_dispatch"                            \
+          --json 'createdAt,databaseId'                          \
+          --jq 'sort_by(.createdAt) | reverse | .[0] | .databaseId'
+    )
     ;;
   *)
     rapids-echo-stderr "RAPIDS_BUILD_TYPE must be one of [branch, nightly, pull-request]"

--- a/tools/rapids-prompt-local-github-auth
+++ b/tools/rapids-prompt-local-github-auth
@@ -7,8 +7,8 @@
 # This exists primarily for interactive use cases, like trying to reproduce CI locally.
 #
 
-if ! gh auth status >/dev/null 2>&1; then
-    rapids-echo-stderr "No GitHub authentication detected."
+if ! gh auth status >&2; then
+    rapids-echo-stderr "Not yet authenticated with GitHub."
     rapids-echo-stderr "Please authenticate with GitHub to continue."
     rapids-echo-stderr "To avoid these interactive prompts in the future, set environment variable 'GH_TOKEN' or run 'gh auth login' with the GitHub CLI."
 
@@ -22,7 +22,7 @@ if ! gh auth status >/dev/null 2>&1; then
         --web \
         --git-protocol https \
         --hostname "github.com" \
-        --skip-ssh-key;
+        --skip-ssh-key >&2;
     then
         rapids-echo-stderr "GitHub authentication failed. Exiting.";
         exit 1;

--- a/tools/rapids-upload-to-anaconda-github
+++ b/tools/rapids-upload-to-anaconda-github
@@ -19,11 +19,12 @@ github_run_id="$(rapids-github-run-id)"
 unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 
 # Download all artifacts with conda in the name to unzip_dest
-rapids-retry gh run download    \
-  "${github_run_id}"            \
-  --repo "${RAPIDS_REPOSITORY}" \
-  --dir "${unzip_dest}"         \
-  --pattern '*conda*'
+RAPIDS_RETRY_SLEEP=30             \
+  rapids-retry gh run download    \
+    "${github_run_id}"            \
+    --repo "${RAPIDS_REPOSITORY}" \
+    --dir "${unzip_dest}"         \
+    --pattern '*conda*'
 
 # Find all directories within unzip_dest
 for artifact_dir in "${unzip_dest}"/*/; do

--- a/tools/rapids-wheels-anaconda-github
+++ b/tools/rapids-wheels-anaconda-github
@@ -43,11 +43,12 @@ unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 rapids-echo-stderr "Downloading ${PKG_TYPE}_${WHEEL_NAME} wheels to ${unzip_dest}"
 
 # Download all artifacts with WHEEL_SEARCH_KEY in the name to unzip_dest
-rapids-retry gh run download        \
-  "${github_run_id}"                \
-  --repo "${RAPIDS_REPOSITORY}"     \
-  --dir "${unzip_dest}"             \
-  --pattern "*${WHEEL_SEARCH_KEY}*"
+RAPIDS_RETRY_SLEEP=30                 \
+  rapids-retry gh run download        \
+    "${github_run_id}"                \
+    --repo "${RAPIDS_REPOSITORY}"     \
+    --dir "${unzip_dest}"             \
+    --pattern "*${WHEEL_SEARCH_KEY}*"
 
 find "${unzip_dest}" -name "*.whl" -exec cp {} "${WHEEL_DIR}/" \;
 


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/shared-workflows/issues/361

As described there, we've observed some CI jobs failing with rate limits from the GitHub API.
This proposes the following to help with that:

* redirecting output from `rapids-prompt-local-github-auth` to stderr instead of `/dev/null`, so it's possible to get more debugging details from logs
* increasing the wait time between retries for all `rapids-retry gh ...` calls from 10 seconds to 30

## Notes for Reviewers

### How I tested this

Locally, like this:

```text
gh auth logout

GH_TOKEN="broken" \
PATH="$(pwd)/tools:${PATH}" \
  rapids-prompt-local-github-auth
```

Saw this output:

```text
github.com
  X Failed to log in to github.com using token (GH_TOKEN)
  - Active account: true
  - The token in GH_TOKEN is invalid.
```

Opened a `cugraph` PR to test this, and saw these changes appear to work: https://github.com/rapidsai/cugraph/pull/5091#issuecomment-2898854542