### PR TITLE
skip 'gh auth status' in CI runs

### DIFF
--- a/tools/_rapids-get-pr-artifact-github
+++ b/tools/_rapids-get-pr-artifact-github
@@ -20,7 +20,7 @@ if [[ "${package_format}" = "wheel" && -z "${RAPIDS_PY_WHEEL_NAME:+placeholder}"
     exit 1
 fi
 
-source rapids-prompt-local-github-auth
+rapids-prompt-local-github-auth
 
 # If commit is not provided, get the latest commit on the PR
 if [[ -z "${commit}" ]]; then

--- a/tools/rapids-download-from-github
+++ b/tools/rapids-download-from-github
@@ -12,7 +12,7 @@ if [ -z "${1:-}" ]; then
   exit 1
 fi
 
-source rapids-prompt-local-github-auth
+rapids-prompt-local-github-auth
 
 github_run_id="$(rapids-github-run-id)"
 pkg_name="$1"
@@ -23,7 +23,7 @@ unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 # by adding them to this block.
 {
   echo "Downloading and decompressing ${pkg_name} from Run ID ${github_run_id} into ${unzip_dest}"
-  RAPIDS_RETRY_SLEEP=30             \
+  RAPIDS_RETRY_SLEEP=120            \
     rapids-retry gh run download    \
       "${github_run_id}"            \
       --repo "${RAPIDS_REPOSITORY}" \

--- a/tools/rapids-github-run-id
+++ b/tools/rapids-github-run-id
@@ -20,13 +20,13 @@
 set -euo pipefail
 export RAPIDS_SCRIPT_NAME="rapids-github-run-id"
 
-source rapids-prompt-local-github-auth
+rapids-prompt-local-github-auth
 
 # While called by CI, all the environment variables are set by the caller. However when run locally, these environment variables are set by rapids-prompt-local-repo-config
 case "${RAPIDS_BUILD_TYPE}" in
   pull-request)
     run_id=${GITHUB_RUN_ID:-$(
-      RAPIDS_RETRY_SLEEP=30                                   \
+      RAPIDS_RETRY_SLEEP=120                                  \
         rapids-retry --quiet gh run list                      \
           --repo "${RAPIDS_REPOSITORY}"                       \
           --branch "${RAPIDS_REF_NAME}"                       \
@@ -37,7 +37,7 @@ case "${RAPIDS_BUILD_TYPE}" in
     ;;
   branch)
     run_id=${GITHUB_RUN_ID:-$(
-      RAPIDS_RETRY_SLEEP=30                                      \
+      RAPIDS_RETRY_SLEEP=120                                     \
         rapids-retry --quiet gh run list                         \
           --repo "${RAPIDS_REPOSITORY}"                          \
           --branch "${RAPIDS_REF_NAME}"                          \
@@ -58,7 +58,7 @@ case "${RAPIDS_BUILD_TYPE}" in
     # From GitHub's perspective, those are different "runs", with different IDs.
     # GitHub Actions organizes artifacts by run ID.
     run_id=$(
-      RAPIDS_RETRY_SLEEP=30                                      \
+      RAPIDS_RETRY_SLEEP=120                                     \
         rapids-retry --quiet gh run list                         \
           --repo "${RAPIDS_REPOSITORY}"                          \
           --branch "${RAPIDS_REF_NAME}"                          \

--- a/tools/rapids-prompt-local-github-auth
+++ b/tools/rapids-prompt-local-github-auth
@@ -32,6 +32,6 @@ elif ! gh auth status >&2; then
         --skip-ssh-key >&2;
     then
         rapids-echo-stderr "GitHub authentication failed. Exiting.";
-        # exit 1;
+        exit 1;
     fi
 fi

--- a/tools/rapids-prompt-local-github-auth
+++ b/tools/rapids-prompt-local-github-auth
@@ -7,7 +7,14 @@
 # This exists primarily for interactive use cases, like trying to reproduce CI locally.
 #
 
-if ! gh auth status >&2; then
+# In CI, assume that we've already authenticated by the time this script is called.
+#
+# 'gh auth status' makes network requests to the GitHub API. Skipping it in CI
+# reduces the risk of hitting GitHub API rate limits.
+#
+if [ "${CI:-false}" = "true" ]; then
+    rapids-echo-stderr "Detected CI=true. Skipping running 'gh auth status'."
+elif ! gh auth status >&2; then
     rapids-echo-stderr "Not yet authenticated with GitHub."
     rapids-echo-stderr "Please authenticate with GitHub to continue."
     rapids-echo-stderr "To avoid these interactive prompts in the future, set environment variable 'GH_TOKEN' or run 'gh auth login' with the GitHub CLI."
@@ -25,6 +32,6 @@ if ! gh auth status >&2; then
         --skip-ssh-key >&2;
     then
         rapids-echo-stderr "GitHub authentication failed. Exiting.";
-        exit 1;
+        # exit 1;
     fi
 fi

--- a/tools/rapids-upload-to-anaconda-github
+++ b/tools/rapids-upload-to-anaconda-github
@@ -19,7 +19,7 @@ github_run_id="$(rapids-github-run-id)"
 unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 
 # Download all artifacts with conda in the name to unzip_dest
-RAPIDS_RETRY_SLEEP=30             \
+RAPIDS_RETRY_SLEEP=120            \
   rapids-retry gh run download    \
     "${github_run_id}"            \
     --repo "${RAPIDS_REPOSITORY}" \

--- a/tools/rapids-wheels-anaconda-github
+++ b/tools/rapids-wheels-anaconda-github
@@ -43,7 +43,7 @@ unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 rapids-echo-stderr "Downloading ${PKG_TYPE}_${WHEEL_NAME} wheels to ${unzip_dest}"
 
 # Download all artifacts with WHEEL_SEARCH_KEY in the name to unzip_dest
-RAPIDS_RETRY_SLEEP=30                 \
+RAPIDS_RETRY_SLEEP=120                \
   rapids-retry gh run download        \
     "${github_run_id}"                \
     --repo "${RAPIDS_REPOSITORY}"     \


### PR DESCRIPTION
We've recently observed some issues across RAPIDS CI that look like we're hitting the GitHub REST API's rate limits: https://github.com/rapidsai/build-infra/issues/241

This proposes some changes to hopefully reduce the incidence of that:

* not running `gh auth status` in CI *(see notes below)*
* increasing the wait between retries of failed `gh` commands from 30 to 120 seconds

Also proposes one minor refactoring:

* invoking, instead of `source`-ing `rapids-prompt-local-github-auth`
  - *not really related to this issue, but it'd reduce the risk of conflicts in variable names*

## Notes for Reviewers

### How does avoiding `gh auth status` calls help?

I found in local testing that those do make network requests!

Try this:

```shell
# authenticate
gh auth login

# check status
gh auth status
```

You should see that succeed. Turn off your WiFi and do that again.

```shell
gh auth status
```

You'll see it fail!

I think the request it's making is to get the scopes for the current token:

https://github.com/cli/cli/blob/1e6a2b1affb7d6a7850f4bc0e7a43cf14b80caf5/pkg/cmd/auth/status/status.go#L214

https://github.com/cli/cli/blob/1e6a2b1affb7d6a7850f4bc0e7a43cf14b80caf5/pkg/cmd/auth/status/status.go#L305

https://github.com/cli/cli/blob/1e6a2b1affb7d6a7850f4bc0e7a43cf14b80caf5/pkg/cmd/auth/shared/oauth_scopes.go#L38

I can't quite tell what endpoint it's hitting so not sure whether that's actually counting towards our rate limit. But avoiding those requests in CI would be valuable even if they don't count against our rate limit... every network request is an opportunity for a build-breaking transient failure 😬 

If these *do* count against our rate limits, then **this PR would cut the number of requests to the GItHub API per run roughly in half**, because `rapids-prompt-local-github-auth` is called on every code path from `gha-tools` invoking the `gh` CLI (as of #172).

### How I tested this

Tested on a `cugraph` PR.

See https://github.com/rapidsai/cugraph/pull/5091#issuecomment-2905308886