### PR TITLE
remove misleading log message about the VPN being required

### DIFF
--- a/tools/rapids-prompt-local-repo-config
+++ b/tools/rapids-prompt-local-repo-config
@@ -20,7 +20,6 @@
 
 if [ "${CI:-false}" = "false" ]; then
   rapids-echo-stderr "Local run detected."
-  rapids-echo-stderr "NVIDIA VPN connectivity is required to download workflow artifacts."
 
   if [ -z "${RAPIDS_BUILD_TYPE:-}" ]; then
     {


### PR DESCRIPTION
When `rapids-prompt-local-repo-config` detects that it is being run outside of a CI job, it emits a log that says NVIDIA VPN access is required to download artifacts.

That's no longer true, as of the switch across RAPIDS to the GitHub Actions artifact store (https://github.com/rapidsai/build-infra/issues/237).

This removes that line.

## Notes for Reviewers

There are other scripts here that do still require VPN access, and those have their own log messages saying that.

https://github.com/rapidsai/gha-tools/blob/ec1f9ccce4fbf7e01077ee2c26a4bc1a661b62d4/tools/rapids-upload-docs#L74-L76

https://github.com/rapidsai/gha-tools/blob/ec1f9ccce4fbf7e01077ee2c26a4bc1a661b62d4/tools/rapids-upload-docs#L122

https://github.com/rapidsai/gha-tools/blob/ec1f9ccce4fbf7e01077ee2c26a4bc1a661b62d4/tools/rapids-upload-to-s3#L38

https://github.com/rapidsai/gha-tools/blob/ec1f9ccce4fbf7e01077ee2c26a4bc1a661b62d4/tools/rapids-upload-artifacts-dir#L33