### PR TITLE
rapids-github-run-id: raise error if no run ID found

### DIFF
--- a/tools/rapids-github-run-id
+++ b/tools/rapids-github-run-id
@@ -75,4 +75,9 @@ case "${RAPIDS_BUILD_TYPE}" in
     ;;
 esac
 
+if [[ -z "${run_id}" ]]; then
+  rapids-echo-stderr "ERROR: failed to find a GitHub Actions run for [RAPIDS_BUILD_TYPE=${RAPIDS_BUILD_TYPE}, RAPID_REPOSITORY=${RAPIDS_REPOSITORY}, RAPIDS_REF_NAME=${RAPIDS_REF_NAME}, RAPIDS_SHA=${RAPIDS_SHA}]"
+  exit 1
+fi
+
 echo -n "${run_id}"


### PR DESCRIPTION
Fixes #192

Today, `rapids-github-run-id` can silently and "successfully" (exit code 0) return an empty string.

This is never desirable in RAPIDS CI... that empty string leads to artifact-downloading grabbing whatever the latests uploaded artifacts happened to be, which can lead to problems of the form "not building/testing against the packages I intended to build/test against".

This can be difficult to recognize if pulling the wrong artifact doesn't result in outright failures.

To avoid that, this PR proposes raising a big loud error in the situation where no run ID is found.

## Notes for Reviewers

### How I tested this

Fails in the expected way for a SHA that does not exist:

```shell
run_id=$(
    PATH="$(pwd)/tools:${PATH}" \
    RAPIDS_BUILD_TYPE=branch \
    RAPIDS_REPOSITORY="rapidsai/rmm" \
    RAPIDS_REF_NAME="branch-25.08" \
    RAPIDS_SHA="some-nonsense-that-does-not-exist" \
    RAPIDS_BUILD_WORKFLOW_NAME="build.yaml" \
      rapids-github-run-id
)

# [rapids-github-run-id] ERROR: failed to find a GitHub Actions run for [RAPIDS_BUILD_TYPE=branch, RAPID_REPOSITORY=rapidsai/rmm, RAPIDS_REF_NAME=branch-25.08, RAPIDS_SHA=some-nonsense-that-does-not-exist]

echo $?
# 1
```

Succeeds as expected for a real commit:

```shell
run_id=$(
    PATH="$(pwd)/tools:${PATH}" \
    RAPIDS_BUILD_TYPE=branch \
    RAPIDS_REPOSITORY="rapidsai/rmm" \
    RAPIDS_REF_NAME="branch-25.08" \
    RAPIDS_SHA="e5b1c01b8600e11872268484af3176a3eeeb8d03" \
    RAPIDS_BUILD_WORKFLOW_NAME="build.yaml" \
      rapids-github-run-id
)

echo $?
# 0

echo $run_id
# 15470752435
```

That exactly corresponds to https://github.com/rapidsai/rmm/actions/runs/15470752435/job/43554265779, which is correct.
