### PR TITLE
chore: remove all cuda11 references from tools, tests, and docs

### DIFF
--- a/tests/test_rapids-find-anaconda-uploads.py
+++ b/tests/test_rapids-find-anaconda-uploads.py
@@ -16,19 +16,19 @@ mod = importlib.import_module("rapids-find-anaconda-uploads")
     "filename, pkg_name",
     [
         (
-            "custreamz-23.02.00a230103-py39_g1deec38683_209.tar.bz2",
+            "custreamz-23.02.00a230103-py312_g1deec38683_209.tar.bz2",
             "custreamz",
         ),
         (
-            "strings_udf-23.02.00a230103-cuda_11_py39_g1deec38683_209.tar.bz2",
+            "strings_udf-23.02.00a230103-cuda_12_py312_g1deec38683_209.tar.bz2",
             "strings_udf",
         ),
         (
-            "dask-cudf-23.02.00a230103-cuda_11_py39_g1deec38683_209.tar.bz2",
+            "dask-cudf-23.02.00a230103-cuda_12_py312_g1deec38683_209.tar.bz2",
             "dask-cudf",
         ),
         (
-            "some-random-long-pkg-name-23.02.00a230103-cuda_11_py39_g1deec38683_209.tar.bz2",
+            "some-random-long-pkg-name-23.02.00a230103-cuda_12_py312_g1deec38683_209.tar.bz2",
             "some-random-long-pkg-name",
         ),
     ],
@@ -56,18 +56,18 @@ def test_is_skip_pkg(env_var, pkg_name, result):
 
 
 TEST_FILES = [
-    "./cudf_conda_python_cuda11_39_x86_64/linux-64/some-pkg-private-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
-    "./cudf_conda_python_cuda11_39_x86_64/linux-64/some-pkg-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
-    "./cudf_conda_python_cuda11_38_x86_64/linux-64/some-pkg-private-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-    "./cudf_conda_python_cuda11_38_x86_64/linux-64/some-pkg-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-    "./cudf_conda_python_cuda11_39_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
-    "./cudf_conda_python_cuda11_39_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
-    "./cudf_conda_python_cuda11_38_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-    "./cudf_conda_python_cuda11_38_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-    "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-tests-23.02.00a-cuda11_g10bab945_72.tar.bz2",
-    "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
-    "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-tests-23.02.00a-cuda11_g10bab945_72.tar.bz2",
-    "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
+    "./cudf_conda_python_cuda12_39_x86_64/linux-64/some-pkg-private-23.02.00a-cuda12_py312_g10bab945_72.tar.bz2",
+    "./cudf_conda_python_cuda12_39_x86_64/linux-64/some-pkg-23.02.00a-cuda12_py312_g10bab945_72.tar.bz2",
+    "./cudf_conda_python_cuda12_38_x86_64/linux-64/some-pkg-private-23.02.00a-cuda12_py313_g10bab945_72.tar.bz2",
+    "./cudf_conda_python_cuda12_38_x86_64/linux-64/some-pkg-23.02.00a-cuda12_py313_g10bab945_72.tar.bz2",
+    "./cudf_conda_python_cuda12_39_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda12_py312_g10bab945_72.tar.bz2",
+    "./cudf_conda_python_cuda12_39_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda12_py312_g10bab945_72.tar.bz2",
+    "./cudf_conda_python_cuda12_38_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda12_py313_g10bab945_72.tar.bz2",
+    "./cudf_conda_python_cuda12_38_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda12_py313_g10bab945_72.tar.bz2",
+    "./cudf_conda_cpp_cuda12_aarch64/linux-aarch64/libcudf-tests-23.02.00a-cuda12_g10bab945_72.tar.bz2",
+    "./cudf_conda_cpp_cuda12_aarch64/linux-aarch64/libcudf-23.02.00a-cuda12_g10bab945_72.tar.bz2",
+    "./cudf_conda_cpp_cuda12_x86_64/linux-64/libcudf-tests-23.02.00a-cuda12_g10bab945_72.tar.bz2",
+    "./cudf_conda_cpp_cuda12_x86_64/linux-64/libcudf-23.02.00a-cuda12_g10bab945_72.tar.bz2",
 ]
 
 
@@ -78,45 +78,45 @@ def test_file_filter_fn():
     with mock.patch.dict(environ, {"SKIP_UPLOAD_PKGS": "some-pkg-private libcudf-tests"}):
         filtered_list = list(filter(file_filter_fn, TEST_FILES))
         assert filtered_list == [
-            "./cudf_conda_python_cuda11_39_x86_64/linux-64/some-pkg-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
-            "./cudf_conda_python_cuda11_38_x86_64/linux-64/some-pkg-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-            "./cudf_conda_python_cuda11_39_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
-            "./cudf_conda_python_cuda11_38_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-            "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
-            "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
+            "./cudf_conda_python_cuda12_39_x86_64/linux-64/some-pkg-23.02.00a-cuda12_py312_g10bab945_72.tar.bz2",
+            "./cudf_conda_python_cuda12_38_x86_64/linux-64/some-pkg-23.02.00a-cuda12_py313_g10bab945_72.tar.bz2",
+            "./cudf_conda_python_cuda12_39_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda12_py312_g10bab945_72.tar.bz2",
+            "./cudf_conda_python_cuda12_38_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda12_py313_g10bab945_72.tar.bz2",
+            "./cudf_conda_cpp_cuda12_aarch64/linux-aarch64/libcudf-23.02.00a-cuda12_g10bab945_72.tar.bz2",
+            "./cudf_conda_cpp_cuda12_x86_64/linux-64/libcudf-23.02.00a-cuda12_g10bab945_72.tar.bz2",
         ]
 
     # w/ empty env var
     with mock.patch.dict(environ, {"SKIP_UPLOAD_PKGS": ""}):
         filtered_list = list(filter(file_filter_fn, TEST_FILES))
         assert filtered_list == [
-            "./cudf_conda_python_cuda11_39_x86_64/linux-64/some-pkg-private-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
-            "./cudf_conda_python_cuda11_39_x86_64/linux-64/some-pkg-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
-            "./cudf_conda_python_cuda11_38_x86_64/linux-64/some-pkg-private-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-            "./cudf_conda_python_cuda11_38_x86_64/linux-64/some-pkg-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-            "./cudf_conda_python_cuda11_39_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
-            "./cudf_conda_python_cuda11_39_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
-            "./cudf_conda_python_cuda11_38_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-            "./cudf_conda_python_cuda11_38_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-            "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-tests-23.02.00a-cuda11_g10bab945_72.tar.bz2",
-            "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
-            "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-tests-23.02.00a-cuda11_g10bab945_72.tar.bz2",
-            "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
+            "./cudf_conda_python_cuda12_39_x86_64/linux-64/some-pkg-private-23.02.00a-cuda12_py312_g10bab945_72.tar.bz2",
+            "./cudf_conda_python_cuda12_39_x86_64/linux-64/some-pkg-23.02.00a-cuda12_py312_g10bab945_72.tar.bz2",
+            "./cudf_conda_python_cuda12_38_x86_64/linux-64/some-pkg-private-23.02.00a-cuda12_py313_g10bab945_72.tar.bz2",
+            "./cudf_conda_python_cuda12_38_x86_64/linux-64/some-pkg-23.02.00a-cuda12_py313_g10bab945_72.tar.bz2",
+            "./cudf_conda_python_cuda12_39_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda12_py312_g10bab945_72.tar.bz2",
+            "./cudf_conda_python_cuda12_39_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda12_py312_g10bab945_72.tar.bz2",
+            "./cudf_conda_python_cuda12_38_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda12_py313_g10bab945_72.tar.bz2",
+            "./cudf_conda_python_cuda12_38_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda12_py313_g10bab945_72.tar.bz2",
+            "./cudf_conda_cpp_cuda12_aarch64/linux-aarch64/libcudf-tests-23.02.00a-cuda12_g10bab945_72.tar.bz2",
+            "./cudf_conda_cpp_cuda12_aarch64/linux-aarch64/libcudf-23.02.00a-cuda12_g10bab945_72.tar.bz2",
+            "./cudf_conda_cpp_cuda12_x86_64/linux-64/libcudf-tests-23.02.00a-cuda12_g10bab945_72.tar.bz2",
+            "./cudf_conda_cpp_cuda12_x86_64/linux-64/libcudf-23.02.00a-cuda12_g10bab945_72.tar.bz2",
         ]
 
     # w/ no env var
     filtered_list = list(filter(file_filter_fn, TEST_FILES))
     assert filtered_list == [
-        "./cudf_conda_python_cuda11_39_x86_64/linux-64/some-pkg-private-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
-        "./cudf_conda_python_cuda11_39_x86_64/linux-64/some-pkg-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
-        "./cudf_conda_python_cuda11_38_x86_64/linux-64/some-pkg-private-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-        "./cudf_conda_python_cuda11_38_x86_64/linux-64/some-pkg-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-        "./cudf_conda_python_cuda11_39_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
-        "./cudf_conda_python_cuda11_39_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda11_py39_g10bab945_72.tar.bz2",
-        "./cudf_conda_python_cuda11_38_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-        "./cudf_conda_python_cuda11_38_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda11_py38_g10bab945_72.tar.bz2",
-        "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-tests-23.02.00a-cuda11_g10bab945_72.tar.bz2",
-        "./cudf_conda_cpp_cuda11_aarch64/linux-aarch64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
-        "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-tests-23.02.00a-cuda11_g10bab945_72.tar.bz2",
-        "./cudf_conda_cpp_cuda11_x86_64/linux-64/libcudf-23.02.00a-cuda11_g10bab945_72.tar.bz2",
+        "./cudf_conda_python_cuda12_39_x86_64/linux-64/some-pkg-private-23.02.00a-cuda12_py312_g10bab945_72.tar.bz2",
+        "./cudf_conda_python_cuda12_39_x86_64/linux-64/some-pkg-23.02.00a-cuda12_py312_g10bab945_72.tar.bz2",
+        "./cudf_conda_python_cuda12_38_x86_64/linux-64/some-pkg-private-23.02.00a-cuda12_py313_g10bab945_72.tar.bz2",
+        "./cudf_conda_python_cuda12_38_x86_64/linux-64/some-pkg-23.02.00a-cuda12_py313_g10bab945_72.tar.bz2",
+        "./cudf_conda_python_cuda12_39_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda12_py312_g10bab945_72.tar.bz2",
+        "./cudf_conda_python_cuda12_39_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda12_py312_g10bab945_72.tar.bz2",
+        "./cudf_conda_python_cuda12_38_aarch64/linux-aarch64/some-pkg-private-23.02.00a-cuda12_py313_g10bab945_72.tar.bz2",
+        "./cudf_conda_python_cuda12_38_aarch64/linux-aarch64/some-pkg-23.02.00a-cuda12_py313_g10bab945_72.tar.bz2",
+        "./cudf_conda_cpp_cuda12_aarch64/linux-aarch64/libcudf-tests-23.02.00a-cuda12_g10bab945_72.tar.bz2",
+        "./cudf_conda_cpp_cuda12_aarch64/linux-aarch64/libcudf-23.02.00a-cuda12_g10bab945_72.tar.bz2",
+        "./cudf_conda_cpp_cuda12_x86_64/linux-64/libcudf-tests-23.02.00a-cuda12_g10bab945_72.tar.bz2",
+        "./cudf_conda_cpp_cuda12_x86_64/linux-64/libcudf-23.02.00a-cuda12_g10bab945_72.tar.bz2",
     ]

--- a/tools/rapids-conda-retry
+++ b/tools/rapids-conda-retry
@@ -6,7 +6,7 @@
 # CondaHTTPError, ChecksumMismatchError, and JSONDecodeError
 #
 # Example usage:
-# $ rapids-conda-retry install cudatoolkit=11.0 rapids=0.16
+# $ rapids-conda-retry install -c rapidsai -c conda-forge rapids=25.06 'cuda-version>=12.0,<=12.8'
 #
 # Configurable options are set using the following env vars:
 #

--- a/tools/rapids-pip-retry
+++ b/tools/rapids-pip-retry
@@ -6,7 +6,7 @@
 # (usually) results from an interrupted network connection
 #
 # Example usage:
-# $ rapids-pip-retry install nvidia-cublas-cu11
+# $ rapids-pip-retry install nvidia-cublas-cu12
 #
 # Configurable options are set using the following env vars:
 #

--- a/tools/rapids-wheel-ctk-name-gen
+++ b/tools/rapids-wheel-ctk-name-gen
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Generates CUDA suffix in the format "cu${VER}" where `$VER`
-# is the CUDA major version (for example, "cu11").
+# is the CUDA major version (for example, "cu12").
 # Positional Arguments:
 #   1) ctk tag
 set -eu -o pipefail


### PR DESCRIPTION
Removes all of the remaining CUDA 11 references from all files.

Resolves #202

xref rapidsai/build-planning#184
