### PR TITLE
pre-commit.ci: run monthly, not weekly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+ci:
+  autoupdate_schedule: 'monthly'
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.5


### PR DESCRIPTION
Proposes running `pre-commit.ci` auto-updates monthly, instead of weekly, to reduce the frequency of PRs like #205 

docs: https://pre-commit.ci/#configuration

## Benefits of these changes

Every merge here kicks off a build in https://github.com/rapidsai/ci-imgs, which is kind of expensive. Reducing the frequency of `pre-commit.ci` updates here will avoid a couple of those builds, saving us a bit of time, money, and CI resources.