### PR TITLE
Filter extras from constraints file

### DIFF
--- a/tools/rapids-generate-pip-constraints
+++ b/tools/rapids-generate-pip-constraints
@@ -28,6 +28,7 @@ if [[ "${RAPIDS_DEPENDENCIES}" == "oldest" ]]; then
         --output requirements \
         --file-key "${file_key}" \
         --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES}" \
+    | sed -E 's/\[[^]]+\]//g' \
     | tee "${out_file}"
 elif [[ "${RAPIDS_DEPENDENCIES}" == "latest" ]]; then
     echo "" > "${out_file}"

--- a/tools/rapids-generate-pip-constraints
+++ b/tools/rapids-generate-pip-constraints
@@ -28,7 +28,7 @@ if [[ "${RAPIDS_DEPENDENCIES}" == "oldest" ]]; then
         --output requirements \
         --file-key "${file_key}" \
         --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES}" \
-    | sed -E 's/\[[^]]+\]//g' \
+    | sed -E 's/\[[^]]*\]//g' \
     | tee "${out_file}"
 elif [[ "${RAPIDS_DEPENDENCIES}" == "latest" ]]; then
     echo "" > "${out_file}"


### PR DESCRIPTION
This change avoids putting extras into constraints.txt files, which do not support them. This is a pretty bare-bones approach. I didn't bother to try to filter out brackets in comments. I wasn't sure whether pip would complain about empty extras lists so I filtered those too.

Without this, we get these errors from pip:
```
ERROR: Constraints cannot have extras
```
See https://github.com/rapidsai/cudf/actions/runs/16889709563/job/47849185122?pr=19604 for an example