### PR TITLE
feat: add `rapids-artifact-name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This project contains some scripts for managing CI artifacts.
 * `rapids-get-pr-artifact`: downloads conda packages or wheels produced by pull rquest CI in another repo
 * `rapids-upload-to-anaconda-github`: downloads conda packages from GitHub Actions artifact store and uploads conda channels on anaconda.org
 * `rapids-wheels-anaconda-github`: downloads wheels from GitHub Actions artifact store and uploads them to the RAPIDS nightly index at https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/
-* `rapids-package-name`: takes a package type and generate the artifact name (e.g. `conda_cpp` -> `rmm_conda_cpp_x86_64.tar.gz`)
+* `rapids-artifact-name`: takes a package type and generates an artifact name (e.g. `conda_cpp librmm rmm --cuda 12.8` -> `rmm_conda_cpp_librmm_amd64_cu12`)
 
 It also contains some scripts for working with CI artifacts on `downloads.rapids.ai`.
 

--- a/tools/rapids-artifact-name
+++ b/tools/rapids-artifact-name
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Generates a standardized artifact name following the template:
+#   python: {repo}_{pkg_type}_{pkg_lang}_{pkg_name}_{arch}_{cpython_version}[_{cuda_version}]
+#   cpp:    {repo}_{pkg_type}_{pkg_lang}_{pkg_name}_{arch}[_{cuda_version}]
+# Positional Arguments:
+#   1) package type (conda_cpp, conda_python, wheel_cpp, wheel_python)
+#   2) package name (e.g. librmm, rmm)
+#   3) repo_name (optional): overrides repo name derived from RAPIDS_REPOSITORY
+# Flags:
+#   --cuda [version]: CUDA version (default value if `version` unspecified: $RAPIDS_CUDA_VERSION)
+#   --py [version]: Python version as e.g. 3.14, 314 (default value if `version` unspecified: $RAPIDS_PY_VERSION)
+#                   (python packages only; mutually exclusive with --stable and --pure)
+#   --stable: set `cpython_version` equal to `abi3` (python packages only)
+#   --pure: set `cpython_version` equal to `pure` (python packages only)
+set -euo pipefail
+export RAPIDS_SCRIPT_NAME="rapids-artifact-name"
+
+cuda_flag=0
+py_flag=0
+stable_flag=0
+pure_flag=0
+cuda_version=""
+py_version=""
+pkg_type=""
+pkg_name=""
+repo_name=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --cuda)
+      cuda_flag=1
+      shift
+      if [[ $# -gt 0 && "$1" != -* ]]; then
+        cuda_version="$1"
+        shift
+      fi
+      ;;
+    --py)
+      py_flag=1
+      shift
+      if [[ $# -gt 0 && "$1" != -* ]]; then
+        py_version="$1"
+        shift
+      fi
+      ;;
+    --stable)
+      stable_flag=1
+      shift
+      ;;
+    --pure)
+      pure_flag=1
+      shift
+      ;;
+    -*)
+      rapids-echo-stderr "Unknown flag: $1. Supported flags: --cuda, --py, --stable, --pure"
+      exit 1
+      ;;
+    *)
+      if [[ -z "${pkg_type}" ]]; then
+        pkg_type="$1"
+        shift
+      elif [[ -z "${pkg_name}" ]]; then
+        pkg_name="$1"
+        shift
+      elif [[ -z "${repo_name}" ]]; then
+        repo_name="$1"
+        shift
+      else
+        rapids-echo-stderr "Too many positional arguments: $1"
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "${pkg_type}" || -z "${pkg_name}" ]]; then
+  rapids-echo-stderr "Usage: rapids-artifact-name PKG_TYPE PKG_NAME [REPO_NAME] --cuda [version] [--py [version] | --stable | --pure]"
+  exit 1
+fi
+
+case "${pkg_type}" in
+  conda_cpp|conda_python|wheel_cpp|wheel_python) ;;
+  *)
+    rapids-echo-stderr "Invalid package type '${pkg_type}'. Must be one of: conda_cpp, conda_python, wheel_cpp, wheel_python"
+    exit 1
+    ;;
+esac
+
+pkg_type_part="${pkg_type%%_*}"
+pkg_lang="${pkg_type##*_}"
+
+if (( stable_flag == 1 && pure_flag == 1 )); then
+  rapids-echo-stderr "Cannot use '--stable' with '--pure'"
+  exit 1
+fi
+
+if (( stable_flag == 1 && py_flag == 1 )); then
+  rapids-echo-stderr "Cannot use '--stable' with '--py'"
+  exit 1
+fi
+
+if (( pure_flag == 1 && py_flag == 1 )); then
+  rapids-echo-stderr "Cannot use '--pure' with '--py'"
+  exit 1
+fi
+
+if [[ "${pkg_lang}" == "cpp" ]] && (( stable_flag == 1 || pure_flag == 1 || py_flag == 1)); then
+  rapids-echo-stderr "'--stable', '--py', and '--pure' are only valid for Python package types"
+  exit 1
+fi
+
+if [[ "${pkg_lang}" == "python" ]] && (( stable_flag == 0 && pure_flag == 0 && py_flag == 0 )); then
+  rapids-echo-stderr "Python packages require one of: --py [version], --stable, --pure"
+  exit 1
+fi
+
+if [[ -z "${repo_name}" ]]; then
+  repo_name="${RAPIDS_REPOSITORY##*/}"
+fi
+
+cuda_field=""
+if (( cuda_flag == 1 )); then
+  if [[ -z "${cuda_version}" ]]; then
+    if [[ -z "${RAPIDS_CUDA_VERSION:-}" ]]; then
+      rapids-echo-stderr "RAPIDS_CUDA_VERSION must be set when using --cuda without a version argument"
+      exit 1
+    fi
+    cuda_version="${RAPIDS_CUDA_VERSION}"
+  fi
+  cuda_field="cu${cuda_version%%.*}"
+fi
+
+if [[ "${pkg_lang}" == "cpp" ]]; then
+  cpython_version=""
+elif (( stable_flag == 1 )); then
+  cpython_version="abi3"
+elif (( pure_flag == 1 )); then
+  cpython_version="pure"
+else
+  if [[ -z "${py_version}" ]]; then
+    if [[ -z "${RAPIDS_PY_VERSION:-}" ]]; then
+      rapids-echo-stderr "RAPIDS_PY_VERSION must be set when using --py without a version argument"
+      exit 1
+    fi
+    py_version="${RAPIDS_PY_VERSION}"
+  fi
+  cpython_version="cp${py_version//./}"
+fi
+
+raw_arch="$(arch)"
+case "${raw_arch}" in
+  x86_64)  arch_field="amd64" ;;
+  aarch64) arch_field="arm64" ;;
+  *)       arch_field="${raw_arch}" ;;
+esac
+
+artifact_name="${repo_name}_${pkg_type_part}_${pkg_lang}_${pkg_name}_${arch_field}"
+if [[ -n "${cpython_version}" ]]; then
+  artifact_name+="_${cpython_version}"
+fi
+if [[ -n "${cuda_field}" ]]; then
+  artifact_name+="_${cuda_field}"
+fi
+
+echo -n "${artifact_name}"

--- a/tools/rapids-package-name
+++ b/tools/rapids-package-name
@@ -1,4 +1,7 @@
 #!/bin/bash
+# DEPRECATED
+# Please use `rapids-artifact-name` instead of `rapids-package-name` to generate consistent artifact names
+#
 # A utility script that generates a package name from a package type
 # Positional Arguments:
 #   1) package type


### PR DESCRIPTION
This is part of rapidsai/build-planning#270

It adds a new tool `rapids-artifact-name` that handles naming more consistently.

The arguments are:

`rapids-artifact-name package_type package_name repo --cuda [version] --py [version] --stable --pure`

`--stable`, `--py [version]`, and `--pure` are mutually exclusive and are only available when naming `python` artifacts.

```sh
> rapids-artifact-name conda_cpp librmm rmm --cuda 12.9
rmm_conda_cpp_librmm_amd64_cu12

> rapids-artifact-name wheel_cpp librmm rmm --cuda 12.9
rmm_wheel_cpp_librmm_amd64_cu12

> rapids-artifact-name conda_python pylibcudf cudf --cuda 13.1 --stable
cudf_conda_python_pylibcudf_amd64_abi3_cu13

> rapids-artifact-name wheel_python pylibcudf cudf --cuda 13.1 --stable
cudf_wheel_python_pylibcudf_amd64_abi3_cu13

> rapids-artifact-name wheel_python dask-cudf cudf --cuda 13.1 --pure
cudf_wheel_python_dask-cudf_amd64_pure_cu13

> rapids-artifact-name wheel_python dask-cudf cudf --pure
cudf_wheel_python_dask-cudf_amd64_pure
```

I tested this in https://github.com/rapidsai/rmm/pull/2370 by vendoring the script as written there (along with some related small changes to `shared-workflows` to allow overriding artifact names in the conda cpp builds)