### PR TITLE
refactor(rapids-get-pr-artifact): rework tool for new artifact naming scheme

### DIFF
--- a/tools/rapids-get-pr-artifact
+++ b/tools/rapids-get-pr-artifact
@@ -8,9 +8,13 @@
 #   4) "wheel" or "conda", to get the wheel or conda package artifact, respectively
 #   5) [optional] full commit hash, to get the artifact for a specific commit
 # Flags:
-#   --noarch: for conda python packages that use RAPIDS_PY_NOARCH_SUFFIX
-#   --stable: for wheel python packages that use stable ABI (abi3)
-#   --pkg_name: specify the package name to download if different from repo name (e.g. pylibraft)
+#   --pkg_name PACKAGE_NAME: specify the package name to download if different from repo name (e.g. pylibraft from raft)
+#                              defaults to `lib{repo name}` for C++ artifacts and `{repo_name}` for Python artifacts
+#   --py [PY_VERSION]: for python packages that don't use the stable ABI (abi3),
+#                      pass `py` to download version-specific artifacts. Defaults to
+#                      `$RAPIDS_PY_VERSION` if Python version is not given.
+#   --noarch: for artifacts built without a strict `$ARCH` dependency (Pure-python packages)
+#   --override-artifact-name ARTIFACT_NAME: pass in full artifact name and override all other flags
 #
 # Additional environment variables recognized by 'rapids-get-pr-artifact':
 #
@@ -20,24 +24,40 @@
 set -euo pipefail
 
 # Parse flags
-noarch_flag=0
-stable_flag=0
 pkg_name_arg=""
+py_flag=0
+noarch_flag=0
+override_flag=0
+override_name=""
+
 positional_args=()
 
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --noarch)
-      noarch_flag=1
-      shift
-      ;;
-    --stable)
-      stable_flag=1
-      shift
-      ;;
     --pkg_name)
       pkg_name_arg="$2"
       shift 2
+      ;;
+    --py)
+      py_flag=1
+      shift
+      # Check if next argument exists and doesn't start with "-" (i.e., it's a version)
+      if [[ $# -gt 0 && "$1" != -* ]]; then
+        py_version="$1"
+        shift
+      else
+        # No argument provided, will use RAPIDS_PY_VERSION
+        py_version="$RAPIDS_PY_VERSION"
+      fi
+      ;;
+    --override-artifact-name)
+      override_name="$2"
+      override_flag=1
+      shift 2
+      ;;
+    --noarch)
+      noarch_flag=1
+      shift
       ;;
     -*)
       echo "Unknown flag: $1" >&2
@@ -56,31 +76,17 @@ if [[ ${#positional_args[@]} -lt 4 ]]; then
   exit 1
 fi
 
+repo_name="${positional_args[0]}"
 repo="rapidsai/${positional_args[0]}"
 pr="${positional_args[1]}"
 package_type="${positional_args[2]}"
 package_format="${positional_args[3]}"
 commit="${positional_args[4]:-}"
 
-# Validate mutually exclusive flags
-if (( noarch_flag == 1 )) && (( stable_flag == 1 )); then
-  rapids-echo-stderr "Error: --noarch and --stable flags are mutually exclusive"
-  exit 1
-fi
-
-# Validate --noarch flag
-if (( noarch_flag == 1 )); then
-  if [[ "${package_format}" != "conda" ]] || [[ "${package_type}" != "python" ]] || [[ -z "${RAPIDS_PY_NOARCH_SUFFIX:-}" ]]; then
-    rapids-echo-stderr "Error: --noarch flag requires package_format='conda', package_type='python', and RAPIDS_PY_NOARCH_SUFFIX environment variable to be set"
-    rapids-echo-stderr "Got: package_format='${package_format}' package_type='${package_type}' RAPIDS_PY_NOARCH_SUFFIX='${RAPIDS_PY_NOARCH_SUFFIX:-<unset>}'"
-    exit 1
-  fi
-fi
-
-# Validate --stable flag
-if (( stable_flag == 1 )); then
+# Validate --py flag
+if (( py_flag == 1 )); then
   if [[ "${package_type:-}" != "python" ]]; then
-    rapids-echo-stderr "Error: --stable flag is only compatible with package_type='python'"
+    rapids-echo-stderr "Error: --py flag is only compatible with package_type='python'"
     rapids-echo-stderr "Got: package_format='${package_format}'"
     exit 1
   fi
@@ -93,18 +99,42 @@ if [[ -z "${commit:-}" ]]; then
     commit=$(rapids-retry --quiet gh pr view "${pr}" --repo "${repo}" --json headRefOid --jq '.headRefOid')
 fi
 
+
 # Generate the artifact name
-if ((stable_flag == 0)); then
-pkg_name=$(
-    RAPIDS_REPOSITORY="${pkg_name_arg:-${repo}}"                   \
-        rapids-package-name "${package_format}_${package_type}"
-)
-# If it's a stable build, pass through stable and cuda flags
+# For `cpp` artifacts, assume a default package name of `lib{repo}`
+# so `libraft` for `raft`
+# For `python` artifacts, assume a default package name of `{repo}`
+if [[ "${package_type:-}" == "cpp" ]]; then
+  PACKAGE_NAME="${pkg_name_arg:-lib${repo_name}}"
 else
-  pkg_name=$(
-      RAPIDS_REPOSITORY="${pkg_name_arg:-${repo}}"                 \
-          rapids-package-name "${package_format}_${package_type}" --stable --cuda "${RAPIDS_CUDA_VERSION}"
-  )
+  PACKAGE_NAME="${pkg_name_arg:-${repo_name}}"
+fi
+
+# Non-cuda-suffixed packages are rare enough that we just assume we need the cuda suffix
+# For the edge cases, uses can use the override functionality
+RAPIDS_ARTIFACT_NAME_ARGS=("${package_format}_${package_type}" "$PACKAGE_NAME" "${repo_name}" "--cuda")
+
+if [[ "${package_type:-}" == "python" && (( $noarch_flag == 0 ))]]; then
+  if (( py_flag == 1 )); then
+    RAPIDS_ARTIFACT_NAME_ARGS+=("--py" "$py_version")
+  else
+    RAPIDS_ARTIFACT_NAME_ARGS+=("--stable")
+  fi
+fi
+
+# Artifacts with an `any` arch are almost always also `pure`, so group those options
+# together to cover 95% of all artifacts.
+if (( noarch_flag == 1 )); then
+  RAPIDS_ARTIFACT_NAME_ARGS+=("--arch" "any" "--pure")
+fi
+pkg_name="$(rapids-artifact-name "${RAPIDS_ARTIFACT_NAME_ARGS[@]}")"
+
+if (( override_flag == 1 )); then
+  pkg_name=$override_name
+fi
+
+if [[ ${GHA_TOOLS_DEBUG:-} == "1" ]]; then
+  rapids-logger "$pkg_name"
 fi
 
 # if RAPIDS_BUILD_WORKFLOW_NAME is set, use that instead of any RAPIDS conventions


### PR DESCRIPTION
This PR updates `rapids-get-pr-artifact` to work with the new artifact naming scheme introduced with rapidsai/build-planning#270

While `rapids-artifact-name` is incredibly _explicit_ and requires specifying nearly all parts of the artifact name, `rapids-get-pr-artifact` should be more user-friendly and not require specifying every aspect of the artifact name.

To do that, I've made the following assumptions which cover 90+% of all artifacts across RAPIDS:

1.  Always assume we're cuda-suffixed
2.  Assume stable ABI packages by default
3.  Assume that cpp artifacts are `lib{repo_name}`
4.  Assume that python artifacts are `{repo_name}`

For the "standard" set of artifact names (that match the above criteria):

e.g. for `cuml` and `rmm` (all artifacts listed below):

```
cuml_conda_cpp_libcuml_aarch64_cu13
cuml_conda_cpp_libcuml_x86_64_cu12
cuml_conda_cpp_libcuml_x86_64_cu13
cuml_conda_python_cuml_aarch64_abi3_cu12
cuml_conda_python_cuml_aarch64_abi3_cu13
cuml_conda_python_cuml_x86_64_abi3_cu12
cuml_conda_python_cuml_x86_64_abi3_cu13
cuml_wheel_cpp_libcuml_aarch64_cu12
cuml_wheel_cpp_libcuml_aarch64_cu13
cuml_wheel_cpp_libcuml_x86_64_cu12
cuml_wheel_cpp_libcuml_x86_64_cu13
cuml_wheel_python_cuml_aarch64_abi3_cu12
cuml_wheel_python_cuml_aarch64_abi3_cu13
cuml_wheel_python_cuml_x86_64_abi3_cu12
cuml_wheel_python_cuml_x86_64_abi3_cu13

rmm_conda_cpp_librmm_aarch64_cu12
rmm_conda_cpp_librmm_aarch64_cu13
rmm_conda_cpp_librmm_x86_64_cu12
rmm_conda_cpp_librmm_x86_64_cu13
rmm_conda_python_rmm_aarch64_abi3_cu12
rmm_conda_python_rmm_aarch64_abi3_cu13
rmm_conda_python_rmm_x86_64_abi3_cu12
rmm_conda_python_rmm_x86_64_abi3_cu13
rmm_wheel_cpp_librmm_aarch64_cu12
rmm_wheel_cpp_librmm_aarch64_cu13
rmm_wheel_cpp_librmm_x86_64_cu12
rmm_wheel_cpp_librmm_x86_64_cu13
rmm_wheel_python_rmm_aarch64_abi3_cu12
rmm_wheel_python_rmm_aarch64_abi3_cu13
rmm_wheel_python_rmm_x86_64_abi3_cu12
rmm_wheel_python_rmm_x86_64_abi3_cu13
```


(I've set `$GHA_TOOLS_DEBUG=1` to log artifact name to `$STDOUT` and use an old PR number to error out on the downloads for testing)

- `rapids-get-pr-artifact cuml 789 cpp conda` -> `cuml_conda_cpp_libcuml_x86_64_cu12` 
- `rapids-get-pr-artifact cuml 789 cpp python` -> `cuml_conda_python_cuml_x86_64_abi3_cu12` 
- `rapids-get-pr-artifact cuml 789 cpp wheel` -> `cuml_wheel_cpp_libcuml_x86_64_cu12` 
- `rapids-get-pr-artifact cuml 789 python wheel` -> `cuml_wheel_python_cuml_x86_64_abi3_cu12`

where `$RAPIDS_CUDA_VERSION` and `$(arch)` are used by default to handle those values in CI.

For repos like `raft`, where the main Python artifact is not simply called `raft`, we use the `--pkg_name` flag:

- `rapids-get-pr-artifact raft 789 wheel python --pkg_name pylibraft` -> `raft_wheel_python_pylibraft_x86_64_abi3_cu12`

For repos like `cucim` which doesn't yet use the stable ABI, we can override the default of looking for stable ABI packages by using `--py`, which defaults to using the value of `$RAPIDS_PY_VERSION`

- `rapids-get-pr-artifact cucim 43 python wheel --py` -> `cucim_wheel_python_cucim_x86_64_cp313_cu12`

For repos that have pure wheels that aren't arch-specific, we can specify those, too:

- `rapids-get-pr-artifact ucxx 43 python wheel --pkg_name distributed-ucxx --noarch` -> `ucxx_wheel_python_distributed-ucxx_any_pure_cu12`

Finally, for repos with less-common artifact names, allow a complete override of all name generation and just pass in the artifact name (using the same `distributed-ucxx` example)

- `rapids-get-pr-artifact ucxx 43 python wheel --override-artifact-name ucxx_wheel_python_distributed-ucxx_any_pure_cu12` -> `ucxx_wheel_python_distributed-ucxx_any_pure_cu12`

Realistically, the defaults cover a solid 90% of all artifacts, and the edge-cases (like pure-Python packages with no CUDA dependency) are unlikely to be used in cross-PR testing.

