### PR TITLE
rapids-wheels-anaconda-github: support sdists

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_schedule: 'monthly'
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.15
+    rev: v0.15.17
     hooks:
       - id: ruff-format
         args: ["--config", "pyproject.toml"]

--- a/tools/rapids-wheels-anaconda-github
+++ b/tools/rapids-wheels-anaconda-github
@@ -7,7 +7,7 @@
 #
 # [usage]
 #
-#   # upload any sdists or wheels found in Github artifacts with names like '*wheel_python_sparkly-unicorn*'
+#   # upload any sdists or wheels found in GitHub artifacts with names like '*wheel_python_sparkly-unicorn*'
 #   rapids-wheels-anaconda-github 'sparkly-unicorn' 'python'
 #
 

--- a/tools/rapids-wheels-anaconda-github
+++ b/tools/rapids-wheels-anaconda-github
@@ -1,13 +1,13 @@
 #!/bin/bash
-# Uploads Python wheels from a GitHub Actions workflow run to Anaconda.org
+# Uploads Python sdists and wheels from a GitHub Actions workflow run to Anaconda.org.
 #
 # Positional Arguments:
-#   1) wheel name
+#   1) package name
 #   2) package type (one of: 'cpp', 'python')
 #
 # [usage]
 #
-#   # upload any wheels found in Github artifacts with names like '*wheel_python_sparkly-unicorn*'
+#   # upload any sdists or wheels found in Github artifacts with names like '*wheel_python_sparkly-unicorn*'
 #   rapids-wheels-anaconda-github 'sparkly-unicorn' 'python'
 #
 
@@ -38,14 +38,13 @@ if [[ -z "${WHEEL_SEARCH_KEY:-}" ]]; then
 fi
 export WHEEL_SEARCH_KEY
 
-WHEEL_DIR="./dist"
-mkdir -p "${WHEEL_DIR}"
+UPLOAD_DIR="$(mktemp -d)"
 
 github_run_id="$(rapids-github-run-id)"
 unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 
-rapids-echo-stderr "Using search key: ${WHEEL_SEARCH_KEY}"
-rapids-echo-stderr "Downloading ${PKG_TYPE}_${WHEEL_NAME} wheels to ${unzip_dest}"
+rapids-echo-stderr "Using search key: '${WHEEL_SEARCH_KEY}'"
+rapids-echo-stderr "Downloading '${PKG_TYPE}_${WHEEL_NAME}' packages to '${unzip_dest}'"
 
 # Download all artifacts with WHEEL_SEARCH_KEY in the name to unzip_dest
 RAPIDS_RETRY_SLEEP=120                \
@@ -55,24 +54,24 @@ RAPIDS_RETRY_SLEEP=120                \
     --dir "${unzip_dest}"             \
     --pattern "*${WHEEL_SEARCH_KEY}*"
 
-find "${unzip_dest}" -name "*.whl" -exec cp {} "${WHEEL_DIR}/" \;
+find "${unzip_dest}" -name "*.tar.gz" -exec cp {} "${UPLOAD_DIR}/" \;
+find "${unzip_dest}" -name "*.whl" -exec cp {} "${UPLOAD_DIR}/" \;
 
-# Check if we found any wheels
-wheel_count=$(find "${WHEEL_DIR}" -name "*.whl" | wc -l)
-if [ "${wheel_count}" -eq 0 ]; then
-  rapids-echo-stderr "No wheel files found in downloaded artifacts"
+# Check if we found any packages
+mapfile -t files_to_upload < <(find "${UPLOAD_DIR}" \( -name "*.whl" -o -name "*.tar.gz" \))
+if [ "${#files_to_upload[@]}" -eq 0 ]; then
+  rapids-echo-stderr "No sdist or wheel files found in downloaded artifacts"
   exit 1
 fi
 
-# Upload all wheels
-rapids-echo-stderr "Uploading ${wheel_count} wheels to Anaconda.org"
+# Upload all packages
+rapids-echo-stderr "Uploading ${#files_to_upload[@]} packages to Anaconda.org"
 export RAPIDS_RETRY_SLEEP=180
-# shellcheck disable=SC2086
 rapids-retry anaconda \
     -t "${RAPIDS_CONDA_TOKEN}" \
     upload \
     --skip-existing \
     --no-progress \
-    "${WHEEL_DIR}"/*.whl
+    "${files_to_upload[@]}"
 
 echo ""


### PR DESCRIPTION
I'd like to start publishing sdists for `jupyterlab-nvdashboard`, to help with repackaging it on conda-forge: https://github.com/rapidsai/jupyterlab-nvdashboard/pull/283

This proposes updating `rapids-wheels-anaconda-github` to also look for sdists in the downloaded CI artifacts, and upload them to `anaconda.org`.

I *think* this is the only change needed in `ci-imgs` / `gha-tools`/ `shared-workflows` to support publishing sdists to the RAPIDS nightly index.

## Notes for Reviewers

### But... the name has `*-wheels-*` in it

I know, I know.

There are a lot of places where we use "wheel" to really mean _"thing that `pip` knows how to install"_.

In my opinion, living with the misnomer for now is preferable to generalizing more of these names. That should absolutely be revisited if we find ourselves building more sdists (related: https://github.com/rapidsai/build-planning/issues/99#issuecomment-2316032847).

### Other required changes?

Nothing needs to change in `ci-imgs`, `shared-workflows`, or any repo-specific build scripts 😁 

Projects that build sdists will automatically have them uploaded, projects that don't should be unaffected.

### How I tested this

On a `jupyterlab-nvdashboard` PR. Built like this:

```shell
python -m build --sdist --wheel
```

Saw `rapids-wheels-anaconda-github` correctly find and upload both the sdist and wheel.

see https://github.com/rapidsai/jupyterlab-nvdashboard/pull/283/changes#r3455486684