### PR TITLE
rapids-wheels-anaconda-github: use a stable directory for uploads

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_schedule: 'monthly'
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.17
+    rev: v0.15.19
     hooks:
       - id: ruff-format
         args: ["--config", "pyproject.toml"]
@@ -22,6 +22,6 @@ repos:
       - id: shellcheck
         args: ["--rcfile", ".shellcheckrc"]
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.25.2
+    rev: v1.26.1
     hooks:
       - id: zizmor

--- a/tools/rapids-wheels-anaconda-github
+++ b/tools/rapids-wheels-anaconda-github
@@ -4,11 +4,15 @@
 # Positional Arguments:
 #   1) package name
 #   2) package type (one of: 'cpp', 'python')
+#   3) upload location: directory that to-be-uploaded packages are written to (optional, default = "./dist")
 #
 # [usage]
 #
 #   # upload any sdists or wheels found in GitHub artifacts with names like '*wheel_python_sparkly-unicorn*'
 #   rapids-wheels-anaconda-github 'sparkly-unicorn' 'python'
+#
+#   # customize upload directory
+#   rapids-wheels-anaconda-github 'sparkly-unicorn' 'python' /tmp/wheels
 #
 
 set -eou pipefail

--- a/tools/rapids-wheels-anaconda-github
+++ b/tools/rapids-wheels-anaconda-github
@@ -20,6 +20,7 @@ if [ -z "${1:-}" ] || [ -z "${2:-}" ]; then
 fi
 WHEEL_NAME="${1}"
 PKG_TYPE="${2}"
+UPLOAD_DIR="${3:-./dist}"
 
 case "${PKG_TYPE}" in
   cpp)
@@ -38,9 +39,7 @@ if [[ -z "${WHEEL_SEARCH_KEY:-}" ]]; then
 fi
 export WHEEL_SEARCH_KEY
 
-UPLOAD_DIR="${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 mkdir -p "${UPLOAD_DIR}"
-
 github_run_id="$(rapids-github-run-id)"
 unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"
 

--- a/tools/rapids-wheels-anaconda-github
+++ b/tools/rapids-wheels-anaconda-github
@@ -38,7 +38,8 @@ if [[ -z "${WHEEL_SEARCH_KEY:-}" ]]; then
 fi
 export WHEEL_SEARCH_KEY
 
-UPLOAD_DIR="$(mktemp -d)"
+UPLOAD_DIR="${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
+mkdir -p "${UPLOAD_DIR}"
 
 github_run_id="$(rapids-github-run-id)"
 unzip_dest="${RAPIDS_UNZIP_DIR:-$(mktemp -d)}"


### PR DESCRIPTION
#263 broke the path in `wheels-publish` workflows where we upload to PyPI.

The relevant code there expects packages to be in `dist/` ([rapidsai/shared-workflows - .github/workflows/wheels-publish.yaml](https://github.com/rapidsai/shared-workflows/blob/3f5f9d01f3873916bf830fdc3e0fd684ccc0befb/.github/workflows/wheels-publish.yaml#L149)), but in #263 I replaced that with `mktemp`.

```text
ERROR    InvalidDistribution: Cannot find file (or expand pattern): 'dist/*'    
Error: Process completed with exit code 1.
```

([jupyterlab-nvdashboard build link](https://github.com/rapidsai/jupyterlab-nvdashboard/actions/runs/28184382922/job/83483178079))

This proposes making that location configurable, so that related steps can all share the same value.

## Notes for Reviewers

Deployment order:

1. merge this PR
2. wait for new images to be built: https://github.com/rapidsai/ci-imgs/actions/workflows/push.yaml
3. merge `shared-workflows` PR: https://github.com/rapidsai/shared-workflows/pull/583