### PR TITLE
rapids-generate-version: respect RAPIDS_VERSION_SUFFIX env variable for non-release builds

### DIFF
--- a/tools/rapids-generate-version
+++ b/tools/rapids-generate-version
@@ -20,6 +20,10 @@ if v.stage:
 else:
     print(v.serialize(format='{base}rc{distance}'))
 ")
+
+    # In some cases (like nightly builds), an additional suffix is passed in to help
+    # differentiate builds. Append that if it's provided.
+    dunamai_version="${dunamai_version}${RAPIDS_VERSION_SUFFIX:-}"
 fi
 
 echo -n "${dunamai_version}"


### PR DESCRIPTION
After this PR, if environment variable `RAPIDS_VERSION_SUFFIX` is non-empty, its value is appended to the output of `rapids-generate-version` on non-release builds.

## Notes for Reviewers

### Motivation

Helps resolve a long-standing issue where newly-built nightly packages aren't published because their version numbers match existing published packages (https://github.com/rapidsai/build-planning/issues/218).

### How I tested this

```console
$ export PATH="$(pwd)/tools:${PATH}"
$ pushd ~/repos/cudf
$ git fetch upstream --tags
$ python -m venv .venv
$ source .venv/bin/activate
$ pip install dunamai

$ env -u RAPIDS_VERSION_SUFFIX rapids-generate-version
26.10.00a93

$ RAPIDS_VERSION_SUFFIX="+abcd" rapids-generate-version
26.10.00a93+abcd

$ RAPIDS_VERSION_SUFFIX=".post1785251654" rapids-generate-version
26.10.00a93.post1785251654
```

See more testing on these PRs:

* https://github.com/rapidsai/cugraph-gnn/pull/508
* https://github.com/rapidsai/shared-workflows/pull/603