### PR TITLE
rapids-datetime-string: like 'rapids-date-string', but second-precision

### DIFF
--- a/tools/rapids-date-string
+++ b/tools/rapids-date-string
@@ -1,19 +1,9 @@
 #!/bin/bash
-# Compute a date string for use in package versions.
+# A utility script produces a date string
 
-# TODO: remove 'RAPIDS_DATE_STRING' once all projects have been converted over to 'RAPIDS_DATETIME_STRING'
-
-# for local builds, just compute right here
-if [ "${CI:-false}" = "false" ]; then
-  RAPIDS_DATE_STRING="$(date +%y%m%d)"
-  RAPIDS_DATETIME_STRING="$(date -u +'%y%m%d%H%M%S')"
-else
+RAPIDS_DATE_STRING="$(date +%y%m%d)"
+if [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
   WORKFLOW_DATE=$(rapids-retry gh run view "${GITHUB_RUN_ID}" --json createdAt | jq -r '.createdAt')
   RAPIDS_DATE_STRING=$(date -d "${WORKFLOW_DATE}" +%y%m%d)
-
-  # In CI, 'RAPIDS_DATETIME_STRING' should already be set in the environment.
-  RAPIDS_DATETIME_STRING="${RAPIDS_DATETIME_STRING:-}"
 fi
-
 export RAPIDS_DATE_STRING
-export RAPIDS_DATETIME_STRING

--- a/tools/rapids-date-string
+++ b/tools/rapids-date-string
@@ -1,9 +1,19 @@
 #!/bin/bash
-# A utility script produces a date string
+# Compute a date string for use in package versions.
 
-RAPIDS_DATE_STRING="$(date +%y%m%d)"
-if [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
+# TODO: remove 'RAPIDS_DATE_STRING' once all projects have been converted over to 'RAPIDS_DATETIME_STRING'
+
+# for local builds, just compute right here
+if [ "${CI:-false}" = "false" ]; then
+  RAPIDS_DATE_STRING="$(date +%y%m%d)"
+  RAPIDS_DATETIME_STRING="$(date -u +'%y%m%d%H%M%S')"
+else
   WORKFLOW_DATE=$(rapids-retry gh run view "${GITHUB_RUN_ID}" --json createdAt | jq -r '.createdAt')
   RAPIDS_DATE_STRING=$(date -d "${WORKFLOW_DATE}" +%y%m%d)
+
+  # In CI, 'RAPIDS_DATETIME_STRING' should already be set in the environment.
+  RAPIDS_DATETIME_STRING="${RAPIDS_DATETIME_STRING:-}"
 fi
+
 export RAPIDS_DATE_STRING
+export RAPIDS_DATETIME_STRING

--- a/tools/rapids-datetime-string
+++ b/tools/rapids-datetime-string
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# rapids-datetime-string
+#
+# Ensure the expected date-time environment variables used in
+# package building are set.
+#
+# Example usage:
+# 
+#   source rapids-datetime-string
+#
+
+# TODO: remove 'RAPIDS_DATE_STRING' once all projects have been converted over to 'RAPIDS_DATETIME_STRING'
+
+if [ "${CI:-false}" = "false" ]; then
+  # for local builds, just compute right here
+  RAPIDS_DATETIME_STRING="$(date -u +'%y%m%d%H%M%S')"
+  export RAPIDS_DATETIME_STRING
+else
+  if [ -z "${RAPIDS_DATETIME_STRING:-}" ]; then
+    rapids-echo-stderr "Expected environment variable 'RAPIDS_DATETIME_STRING' to be set and non-empty."
+    exit 1
+  fi
+fi

--- a/tools/rapids-datetime-string
+++ b/tools/rapids-datetime-string
@@ -9,9 +9,6 @@
 # 
 #   source rapids-datetime-string
 #
-
-# TODO: remove 'RAPIDS_DATE_STRING' once all projects have been converted over to 'RAPIDS_DATETIME_STRING'
-
 if [ "${CI:-false}" = "false" ]; then
   # for local builds, just compute right here
   RAPIDS_DATETIME_STRING="$(date -u +'%y%m%d%H%M%S')"

--- a/tools/rapids-datetime-string
+++ b/tools/rapids-datetime-string
@@ -6,7 +6,7 @@
 # package building are set.
 #
 # Example usage:
-# 
+#
 #   source rapids-datetime-string
 #
 if [ "${CI:-false}" = "false" ]; then


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/218

Complements https://github.com/rapidsai/shared-workflows/pull/608

For conda builds, RAPIDS projects run `source rapids-date-string` and then thread the environment variable it sets (`RAPIDS_DATE_STRING`) through into conda package build strings, like this:

```shell
source rapids-date-string
```

([rapidsai/cuml - ci/build_cpp.sh](https://github.com/rapidsai/cuml/blob/74f5ffae8f72ca38618b55d84ad234067abd64c1/ci/build_cpp.sh#L8))

```yaml
context:
  ...
  date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
  ...

...

outputs:
  - package:
      name: libcuml
      version: ${{ version }}
      ...
      string: cuda${{ cuda_major }}_${{ date_string }}_${{ head_rev }}
```

([rapidsai/cuml - conda/recipes/libcuml/recipe.yaml](https://github.com/rapidsai/cuml/blob/74f5ffae8f72ca38618b55d84ad234067abd64c1/conda/recipes/libcuml/recipe.yaml#L100))

In https://github.com/rapidsai/build-planning/issues/218 we're moving from `YYMMDD` date components to `YYMMDDhhmmss`, and prefer to have a different variable name (`RAPIDS_DATETIME_STRING`) ... this introduces a new `rapids-datetime-string` for that purpose.

## Notes for Reviewers

### We can remove `rapids-date-string` soon

From GitHub searches, it seems to me that `rapids-date-string` and environment variable `RAPIDS_DATE_STRING` are only used in CI builds of RAPIDS conda packages.

Once all repos are switched over to `rapids-datetime-string` / `RAPIDS_DATETIME_STRING`, we could remove `rapids-date-string`.

Nice side benefit... that'll cut out some GitHub API calls from our CI, because builds we'll no longer execute this on every  run of a `ci/build_{cpp,python}.sh` script:

https://github.com/rapidsai/gha-tools/blob/02ea00f8c3b257c8aeb94cb757724932e70ce0e2/tools/rapids-date-string#L5-L8