### PR TITLE
`rapids-generate-pip-constraints`: specify `cuda_suffixed=true`

### DIFF
--- a/tools/rapids-generate-pip-constraints
+++ b/tools/rapids-generate-pip-constraints
@@ -26,5 +26,5 @@ out_file="${2}"
 rapids-dependency-file-generator \
     --output requirements \
     --file-key "${file_key}" \
-    --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES};use_cuda_wheels=true" \
+    --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION};dependencies=${RAPIDS_DEPENDENCIES};cuda_suffixed=true;use_cuda_wheels=true" \
 | tee -a "${out_file}"


### PR DESCRIPTION
In order to support https://github.com/rapidsai/pre-commit-hooks/issues/132, matrix parameters like `cuda_suffixed` have to be explicit so that the `verify-dependencies` hook doesn't produce false positives. Make it explicit so we can use the hook.